### PR TITLE
chore: PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+**What is the problem this PR is trying to solve?**
+
+**What is the chosen solution to this problem?**
+
+**Please check if the PR fulfills these requirements**
+
+- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
+- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
+- [ ] Docs have been added / updated (for bug fixes / features)
+- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
+
+<!-- You can add more checkboxes here -->
+
+**[ ] This PR introduces a breaking change**
+
+<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->
+
+<!-- **Original Template** -->
+
+<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No PR template

**What is the chosen solution to this problem?**
Same PR template as talend/ui

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
