### PR TITLE
chore: upgrade node and use npm in CI

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,8 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: |
-          yarn
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm install
       - uses: chromaui/action@v1
         with:
           appCode: ${{ secrets.CHROMATIC_APP_CODE }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- CI use yarn, but we removed the yarn/lock
- node version used in CI dies't support `?.` operator

**What is the chosen solution to this problem?**
- use npm
- upgrade node to 14

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
