### PR TITLE
feat(textarea): auto height

### DIFF
--- a/src/components/Form/Field/Field.style.js
+++ b/src/components/Form/Field/Field.style.js
@@ -42,9 +42,10 @@ export const Field = styled.div(
 	}
 	
 	textarea {
-	  	display: block;
+		min-height: 5.4rem;
+		max-height: 30rem;
+ 		resize: none; 		
  		overflow: hidden;
- 		resize: none;
 	}
 	
 	textarea,

--- a/src/components/Form/Field/Field.style.js
+++ b/src/components/Form/Field/Field.style.js
@@ -41,6 +41,12 @@ export const Field = styled.div(
 		}
 	}
 	
+	textarea {
+	  	display: block;
+ 		overflow: hidden;
+ 		resize: none;
+	}
+	
 	textarea,
     select[multiple] {
 		padding: 1rem;

--- a/src/components/Form/Field/Field.style.js
+++ b/src/components/Form/Field/Field.style.js
@@ -44,7 +44,8 @@ export const Field = styled.div(
 	textarea {
 		min-height: 5.4rem;
 		max-height: 30rem;
- 		resize: none; 		
+ 		resize: none;
+ 		white-space: normal;		
  		overflow: hidden;
 	}
 	

--- a/src/components/Form/Field/Textarea/Textarea.js
+++ b/src/components/Form/Field/Textarea/Textarea.js
@@ -2,8 +2,30 @@ import React from 'react';
 import Field from '../Field';
 
 function Textarea({ children, ...rest }) {
+	const textarea = React.createRef();
+
+	function getScrollHeight(elm) {
+		var savedValue = elm.value;
+		elm.value = '';
+		elm._baseScrollHeight = elm.scrollHeight;
+		elm.value = savedValue;
+	}
+
+	function autosize() {
+		const elm = textarea.current;
+		var minRows = +elm.getAttribute('data-min-rows') || 0,
+			rows;
+		if (!elm._baseScrollHeight) {
+			getScrollHeight(elm);
+		}
+
+		elm.rows = minRows;
+		rows = Math.ceil((elm.scrollHeight - elm._baseScrollHeight) / 16);
+		elm.rows = minRows + rows;
+	}
+
 	return (
-		<Field as="textarea" {...rest}>
+		<Field as="textarea" ref={textarea} row={3} data-min-rows="3" {...rest} onInput={autosize}>
 			{children}
 		</Field>
 	);

--- a/src/components/Form/Field/Textarea/Textarea.js
+++ b/src/components/Form/Field/Textarea/Textarea.js
@@ -1,31 +1,17 @@
 import React from 'react';
 import Field from '../Field';
 
-function Textarea({ children, ...rest }) {
+function Textarea({ children, row = 3, ...rest }) {
 	const textarea = React.createRef();
-
-	function getScrollHeight(elm) {
-		var savedValue = elm.value;
-		elm.value = '';
-		elm._baseScrollHeight = elm.scrollHeight;
-		elm.value = savedValue;
-	}
 
 	function autosize() {
 		const elm = textarea.current;
-		var minRows = +elm.getAttribute('data-min-rows') || 0,
-			rows;
-		if (!elm._baseScrollHeight) {
-			getScrollHeight(elm);
-		}
-
-		elm.rows = minRows;
-		rows = Math.ceil((elm.scrollHeight - elm._baseScrollHeight) / 16);
-		elm.rows = minRows + rows;
+		elm.style.height = '1rem';
+		elm.style.height = `${elm.scrollHeight}px`;
 	}
 
 	return (
-		<Field as="textarea" ref={textarea} row={3} data-min-rows="3" {...rest} onInput={autosize}>
+		<Field as="textarea" onInput={autosize} ref={textarea} row={row} {...rest}>
 			{children}
 		</Field>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
textarea are resizable by default

**What is the chosen solution to this problem?**
now they have an auto-height depending on their content

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
