### PR TITLE
fix(Icons): replace name attribute by class tc-icon-name-

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement, useRef } from 'react';
+import React, { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import classnames from 'classnames';
 import { IconName } from '@talend/icons';
@@ -94,6 +94,7 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
 		const [content, setContent] = React.useState<string>();
 
 		const isRemote = name.startsWith('remote-');
+		const isImg = name.startsWith('src-');
 		const imgSrc = name.replace('remote-', '').replace('src-', '');
 		const isRemoteSVG =
 			isRemote && content && content.includes('svg') && !content.includes('script');
@@ -157,13 +158,13 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
 			}
 		}, [border, safeRef]);
 
-		if (name.startsWith('src-')) {
+		if (isImg) {
 			return (
 				<img alt="" src={name.substring(4)} className="tc-icon" {...accessibility} {...rest} />
 			);
 		}
 
-		const classname = classnames('tc-svg-icon', className, transform);
+		const classname = classnames('tc-svg-icon', className, transform, { [`tc-icon-name-${name}`]: !(isImg || isRemote) });
 
 		let iconElement = (
 			<SVG {...rest} {...accessibility} className={classname} border={border} ref={safeRef} />
@@ -187,3 +188,4 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
 );
 
 export const IconMemo = React.memo(Icon);
+IconMemo.displayName = 'Icon';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The UI Icon component put attribute name on svg element.
Some test rely on it.
But it is not valid :/
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg

**What is the chosen solution to this problem?**

add a className to replace it.

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
