### PR TITLE
feat(Icon): preserveColor props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/design-system",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Talend Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -31,7 +31,7 @@ const Button: React.FC<ButtonProps> = React.forwardRef(
 			aria-busy={!!loading}
 		>
 			{loading && <Loading className="btn__loading" name={icon} aria-hidden />}
-			{!loading && icon && <Icon className="btn__icon" name={icon} currentColor />}
+			{!loading && icon && <Icon className="btn__icon" name={icon} />}
 			<span className={`btn__text ${hideText ? 'btn__text--hidden' : ''}`}>{children}</span>
 		</S.Button>
 	),

--- a/src/components/Form/Field/Input/Input.File.js
+++ b/src/components/Form/Field/Input/Input.File.js
@@ -201,7 +201,7 @@ function InputFile(props) {
 					/>
 					{!files ? (
 						<div className="input-file__text text">
-							<Icon className="text__icon" name="talend-upload" currentColor />{' '}
+							<Icon className="text__icon" name="talend-upload" />{' '}
 							<span className="text__span">
 								Drop your files or <Link className="text__link">browse</Link>
 							</span>

--- a/src/components/Form/Field/Select/Select.js
+++ b/src/components/Form/Field/Select/Select.js
@@ -32,9 +32,7 @@ function Select({ children, multiple, readOnly, required, placeholder, ...rest }
 				as="select"
 				multiple={multiple}
 				{...rest}
-				before={
-					!multiple && <Icon name="talend-caret-down" className="talend-caret-down" currentColor />
-				}
+				before={!multiple && <Icon name="talend-caret-down" className="talend-caret-down" />}
 			>
 				{placeholder && (
 					<option value="" disabled selected>

--- a/src/components/HeaderBar/docs/HeaderBar.js
+++ b/src/components/HeaderBar/docs/HeaderBar.js
@@ -16,7 +16,7 @@ export const PortalOnBoarding = () => (
 	<HeaderBar>
 		<HeaderBar.Logo full>
 			<Link href="#">
-				<Icon name="talend-logo" currentColor />
+				<Icon name="talend-logo" />
 				<VisuallyHidden>Talend</VisuallyHidden>
 			</Link>
 		</HeaderBar.Logo>
@@ -28,7 +28,7 @@ export const Portal = () => {
 		<HeaderBar>
 			<HeaderBar.Logo full>
 				<Link href="#">
-					<Icon name="talend-logo" currentColor />
+					<Icon name="talend-logo" />
 					<VisuallyHidden>Talend</VisuallyHidden>
 				</Link>
 			</HeaderBar.Logo>

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -22,7 +22,7 @@ export enum SVG_TRANSFORMS {
 export type IconProps = PropsWithChildren<any> & {
 	name: IconName;
 	transform: SVG_TRANSFORMS;
-	currentColor: boolean;
+	preserveColor: boolean;
 	border: boolean;
 };
 
@@ -35,12 +35,12 @@ const SVG = styled.svg<IconProps>`
 	path,
 	polygon,
 	polyline {
-		${({ currentColor }) => currentColor && 'fill: currentColor;'};
+		${({ preserveColor }) => preserveColor || 'fill: currentColor;'};
 		${({ border }) => border && 'transform: translate(25%, 25%);'};
 	}
 
 	.ti-background {
-		${({ border, currentColor }) => !border && currentColor && 'display: none;'};
+		${({ border, preserveColor }) => !border && !preserveColor && 'display: none;'};
 	}
 
 	.ti-border {
@@ -164,10 +164,19 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
 			);
 		}
 
-		const classname = classnames('tc-svg-icon', className, transform, { [`tc-icon-name-${name}`]: !(isImg || isRemote) });
+		const classname = classnames('tc-svg-icon', className, transform, {
+			[`tc-icon-name-${name}`]: !(isImg || isRemote),
+		});
 
 		let iconElement = (
-			<SVG {...rest} name={!(isImg || isRemote) ? name : null} {...accessibility} className={classname} border={border} ref={safeRef} />
+			<SVG
+				{...rest}
+				name={!(isImg || isRemote) ? name : null}
+				{...accessibility}
+				className={classname}
+				border={border}
+				ref={safeRef}
+			/>
 		);
 
 		if (isRemote && content && !isRemoteSVG) {
@@ -188,4 +197,5 @@ export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
 );
 
 export const IconMemo = React.memo(Icon);
+
 IconMemo.displayName = 'Icon';

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -60,16 +60,12 @@ const Link: React.FC<LinkProps> = React.forwardRef(
 				ariaDisabled={disabled ? 'true' : null}
 				ref={ref}
 			>
-				{iconBefore && (
-					<Icon className="link__icon link__icon--before" name={iconBefore} currentColor />
-				)}
+				{iconBefore && <Icon className="link__icon link__icon--before" name={iconBefore} />}
 				<span className="link__text">{children}</span>
 				{isExternal && !hideExternalIcon && (
-					<Icon className="link__icon link__icon--external" name="talend-link" currentColor />
+					<Icon className="link__icon link__icon--external" name="talend-link" />
 				)}
-				{iconAfter && (
-					<Icon className="link__icon link__icon--after" name={iconAfter} currentColor />
-				)}
+				{iconAfter && <Icon className="link__icon link__icon--after" name={iconAfter} />}
 			</S.Link>
 		);
 	},

--- a/src/docs/Icons.component.js
+++ b/src/docs/Icons.component.js
@@ -86,7 +86,7 @@ export const Icons = () => {
 								name={iconName}
 								style={{ width: size + 'rem', height: size + 'rem' }}
 								transform={transform}
-								currentColor={useCurrentColor ? currentColor : null}
+								preserveColor={!useCurrentColor}
 								border={border}
 							/>
 						</IconItem>

--- a/src/pages/blocks/HeaderBar.tsx
+++ b/src/pages/blocks/HeaderBar.tsx
@@ -20,7 +20,7 @@ export default function HeaderBarBlock() {
 			<HeaderBar.Logo full>
 				<Tooltip title="Talend Portal" placement="bottom">
 					<Link href="#">
-						<Icon name="talend-logo" currentColor />
+						<Icon name="talend-logo" />
 						<VisuallyHidden>Talend</VisuallyHidden>
 					</Link>
 				</Tooltip>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
**Icon** should use currentColor by default

**What is the chosen solution to this problem?**
**Icon** has now `preserveColor` instead of `currentColor` props

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
