### PR TITLE
fix(Icons): currentColor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/design-system",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Talend Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -27,6 +27,7 @@ export type IconProps = PropsWithChildren<any> & {
 };
 
 const SVG = styled.svg<IconProps>`
+	fill: currentColor;
 	width: ${tokens.sizes.l};
 	height: ${tokens.sizes.l};
 	transform-origin: center;
@@ -35,13 +36,13 @@ const SVG = styled.svg<IconProps>`
 	path,
 	polygon,
 	polyline {
-		${({ preserveColor }) => preserveColor || 'fill: currentColor;'};
+		// 	${({ preserveColor }) => (preserveColor ? '' : 'fill: currentColor;')};
 		${({ border }) => border && 'transform: translate(25%, 25%);'};
 	}
 
-	.ti-background {
-		${({ border, preserveColor }) => !border && !preserveColor && 'display: none;'};
-	}
+	// .ti-background {
+	// 	${({ border, preserveColor }) => !border && !preserveColor && 'display: none;'};
+	// }
 
 	.ti-border {
 		${({ border }) => border && 'stroke: currentColor; fill: none; transform: none'};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Icons used setting a currentColor by default in Talend/ui

**What is the chosen solution to this problem?**
Let's keep this behavior for now

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
