### PR TITLE
chore(components): IconsProvider wait for all bundles

### DIFF
--- a/src/components/IconsProvider/IconsProvider.tsx
+++ b/src/components/IconsProvider/IconsProvider.tsx
@@ -62,7 +62,7 @@ function injectIcon(id: string, container: Element) {
 		}
 		container.appendChild(element.children[0].cloneNode(true));
 	} else if (Object.keys(FETCHING_BUNDLES).length) {
-		Promise.all(Object.values(FETCHING_BUNDLES)).then(() => injectIcon(id, container));
+		Promise.any(Object.values(FETCHING_BUNDLES)).then(() => injectIcon(id, container));
 	}
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The IconsProvider component allow to define several icon bundles to fetch.
When an icon try to render, it use the provider to search the right icon in all bundles. To do that, it waits all bundles to have been fetched. If one of the bundle take an anormal amount of time to load, it delays all icons display.

For example, if you go to pipeline designer, processors icons can take 3s to load (depends on the number of engine and processor you can access to). So the page loads without any icons for almost 4s.

**What is the chosen solution to this problem?**
Instead of waiting all bundles to be loaded, try to display the icon everytime a new bundle is loaded.

To do that, the Promise.all made on bundles is replaced by Promise.any.

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
