### PR TITLE
fix(iconsprovider): create svg using namespace

### DIFF
--- a/src/components/IconsProvider/IconsProvider.tsx
+++ b/src/components/IconsProvider/IconsProvider.tsx
@@ -73,7 +73,7 @@ function addBundle(response: Response) {
 	if (response.status === 200 && response.ok) {
 		return response.text().then(content => {
 			if (content.startsWith('<svg')) {
-				const container = document.createElement('svg');
+				const container = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 				container.setAttribute('class', 'tc-iconsprovider');
 				container.setAttribute('style', 'display: none');
 				container.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We used to create an SVG provider without a namespace, which it's not a real SVGSVGElement

**What is the chosen solution to this problem?**
Add the namespace

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
