### PR TITLE
feat(Accordion): dark mode

### DIFF
--- a/src/components/Accordion/Accordion.style.ts
+++ b/src/components/Accordion/Accordion.style.ts
@@ -11,7 +11,7 @@ export const Accordion = styled(ReakitComposite)`
 export const AccordionItem = styled.div`
 	margin: ${tokens.space.m} 0;
 	min-width: 25rem;
-	border: 1px solid ${tokens.colors.gray[100]};
+	border: 1px solid ${({ theme }) => theme.colors.accordionBorderColor};
 	border-radius: ${tokens.radii.rectRadius};
 
 	&:hover {
@@ -34,7 +34,7 @@ export const DisclosureHeading = styled.div<{ visible: boolean }>`
 		props.visible
 			? `${tokens.radii.rectRadius} ${tokens.radii.rectRadius} 0 0`
 			: tokens.radii.rectRadius};
-	background: ${tokens.colors.gray[50]};
+	background: ${({ theme }) => theme.colors.accordionBackgroundColor};
 `;
 
 export const DisclosureArrow = styled.span`

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -15,6 +15,10 @@ declare module 'styled-components' {
 			activeColor: string;
 			backgroundColor: string;
 
+			// Accordions
+			accordionBorderColor: string;
+			accordionBackgroundColor: string;
+
 			// Buttons
 			buttonPrimaryColor: string;
 			buttonPrimaryBackgroundColor: string;

--- a/src/themes/dark.theme.ts
+++ b/src/themes/dark.theme.ts
@@ -20,9 +20,10 @@ const theme: DefaultTheme = {
 		...palette,
 
 		textColor: palette.grayColor[0],
-		focusColor: palette.focusColor[500],
-		activeColor: palette.primaryColor[500],
 		backgroundColor: palette.grayColor[900],
+
+		accordionBorderColor: palette.grayColor[800],
+		accordionBackgroundColor: palette.grayColor[700],
 
 		buttonPrimaryColor: palette.grayColor[900],
 		buttonPrimaryBackgroundColor: palette.primaryColor[500],

--- a/src/themes/light.theme.ts
+++ b/src/themes/light.theme.ts
@@ -22,6 +22,9 @@ const theme: DefaultTheme = {
 		textColor: palette.grayColor[900],
 		backgroundColor: palette.grayColor[0],
 
+		accordionBorderColor: palette.grayColor[100],
+		accordionBackgroundColor: palette.grayColor[50],
+
 		buttonPrimaryColor: palette.grayColor[0],
 		buttonPrimaryBackgroundColor: palette.primaryColor[500],
 		buttonPrimaryHoverBackgroundColor: palette.primaryColor[600],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`Accordion` was too shinny with dark mode

**What is the chosen solution to this problem?**
Add some design tokens to temp fix this

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
