### PR TITLE
feat(Switch): onChange

### DIFF
--- a/src/components/Switch/Switch.style.ts
+++ b/src/components/Switch/Switch.style.ts
@@ -13,11 +13,10 @@ export const SwitchIndicator = styled.span`
 	z-index: ${tokens.zIndices.above};
 `;
 
-export const Switch = styled.div<{ values: any[]; disabled: boolean; readOnly: boolean }>`
+export const Switch = styled.div<{ disabled: boolean; readOnly: boolean }>`
 	div {
 		position: relative;
     	display: inline-flex;
-		padding: 0 1rem;
 		background: ${({ theme }) => theme.colors.inputRadioBackgroundColor};
 		border-radius: 10rem;
 		box-shadow: inset 0 .1rem .3rem 0 rgba(0, 0, 0, .25);
@@ -30,6 +29,7 @@ export const Switch = styled.div<{ values: any[]; disabled: boolean; readOnly: b
 		display: flex;
 		align-items: center;
 		justify-content: space-around;
+		margin: 0;
 		padding: 0 1rem;
 		color: ${({ theme }) => theme.colors.textColor}
 		font-size: ${tokens.fontSizes.small};
@@ -41,14 +41,6 @@ export const Switch = styled.div<{ values: any[]; disabled: boolean; readOnly: b
 		z-index: ${tokens.zIndices.onTop};
 	}
 	
-	button:nth-child(1) {
-		padding-left: 0;
-	}
-	
-	button:nth-child(${({ values }) => values.length}) {
-		padding-right: 0;
-	}
-
 	${SwitchIndicator} em {
   		position: absolute;
   		top: .2rem;
@@ -65,20 +57,20 @@ export const Switch = styled.div<{ values: any[]; disabled: boolean; readOnly: b
 			!readOnly ? shade(0.25, theme.colors.activeColor[500]) : 'none'};
 	}
   
-	[data-checked] {
+	[aria-selected] {
 		transition: color ${tokens.transitions.normal};
 	}
 	
-	[data-checked="true"] {
+	[aria-selected="true"] {
 		color: ${({ theme }) => theme.colors.inputBackgroundColor};
 		opacity: ${tokens.opacity.opaque};
 	}
 		
-	[data-checked] ~ ${SwitchIndicator} {
+	[aria-selected] ~ ${SwitchIndicator} {
 		visibility: hidden;
 	}
 	
-	[data-checked="true"] ~ ${SwitchIndicator} {
+	[aria-selected="true"] ~ ${SwitchIndicator} {
 		visibility: visible;
 	}
 `;

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -53,27 +53,22 @@ const Switch = ({
 		const checkedRadioIndex = radioGroupChildren.indexOf(checkedElement);
 		const checkedRadioSpanWidth = checkedElement.scrollWidth;
 		const switchIndicatorRef = switchIndicator?.current;
-		const isFirst = checkedRadioIndex === 0;
-		const isLast = checkedRadioIndex === radioWidths.length - 1;
 		if (switchIndicatorRef) {
-			switchIndicatorRef.style.transform = `translateX(${
-				radioWidths
-					.slice(0, checkedRadioIndex)
-					.reduce((accumulator, currentValue) => accumulator + currentValue, 0) +
-				(!isFirst ? 10 : 0)
-			}px)`;
-			switchIndicatorRef.style.width = `${checkedRadioSpanWidth + (isFirst || isLast ? 10 : 0)}px`;
+			switchIndicatorRef.style.transform = `translateX(${radioWidths
+				.slice(0, checkedRadioIndex)
+				.reduce((accumulator, currentValue) => accumulator + currentValue, 0)}px)`;
+			switchIndicatorRef.style.width = `${checkedRadioSpanWidth}px`;
 		}
 	}, [radio]);
 
 	return (
-		<S.Switch values={values} readOnly={readOnly} disabled={disabled}>
+		<S.Switch readOnly={readOnly} disabled={disabled}>
 			<RadioGroup {...rest} {...radio} ref={containerRef} aria-label={label} disabled={disabled}>
 				{values.map((v: string, i: number) => {
 					const isChecked = radio.state === v;
 					return (
 						<Radio
-							onChange={event => onChange(event, v)}
+							onChange={event => onChange && onChange(event, v)}
 							{...radio}
 							value={v}
 							as="button"

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -12,7 +12,16 @@ export type SwitchProps = React.PropsWithChildren<any> & {
 	readOnly: boolean;
 };
 
-const Switch = ({ label, value, values, checked, disabled, readOnly, ...rest }: SwitchProps) => {
+const Switch = ({
+	label,
+	value,
+	values,
+	checked,
+	disabled,
+	readOnly,
+	onChange,
+	...rest
+}: SwitchProps) => {
 	const radio = useRadioState({
 		state: value || (values && values[0]),
 		loop: false,
@@ -63,7 +72,14 @@ const Switch = ({ label, value, values, checked, disabled, readOnly, ...rest }: 
 				{values.map((v: string, i: number) => {
 					const isChecked = radio.state === v;
 					return (
-						<Radio {...radio} value={v} as="button" key={i} data-checked={isChecked}>
+						<Radio
+							onChange={event => onChange(event, v)}
+							{...radio}
+							value={v}
+							as="button"
+							key={i}
+							data-checked={isChecked}
+						>
 							{v}
 						</Radio>
 					);

--- a/src/components/Switch/docs/Switch.stories.mdx
+++ b/src/components/Switch/docs/Switch.stories.mdx
@@ -19,7 +19,7 @@ Switches are a quick way to make a selection between two states (or three someti
 
 <Canvas>
     <Story name="default">
-        <Switch values={['input', 'both', 'ouput']} />
+        <Switch values={['input', 'both', 'output']} />
 	</Story>
  </Canvas>
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`Switch` has no onChange handler

**What is the chosen solution to this problem?**
Add it to each radio button

```jsx
<Switch onChange={(event, value) => console.log(value)} values={['a', 'b', 'c']} />
```

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
