### PR TITLE
fix(Tabs): icon color when active

### DIFF
--- a/src/components/Tabs/Tabs.style.ts
+++ b/src/components/Tabs/Tabs.style.ts
@@ -50,7 +50,6 @@ export const Tab = styled(ReakitTab)`
 		margin-right: ${tokens.space.xs};
 		width: ${tokens.sizes.s};
 		height: ${tokens.sizes.s};
-		color: ${({ theme }) => theme.colors.textColor};
 	}
 
 	.tag {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`Icon` color was fixed to the default text color.
It's wrong when the tab is active.

**What is the chosen solution to this problem?**
Use `currentColor` as default

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
