### PR TITLE
doc: bump TOC version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-dom": "^16.14.0",
     "react-is": "^16.13.1",
     "storybook-addon-pseudo-states": "^1.0.0-rc.3",
-    "storybook-docs-toc": "^1.2.0",
+    "storybook-docs-toc": "^1.3.1",
     "styled-components": "^5.2.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14763,10 +14763,10 @@ storybook-addon-pseudo-states@^1.0.0-rc.3:
   resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-1.0.0-rc.3.tgz#e1158667021a2400fad75cbd3e06328dcbebb584"
   integrity sha512-i3syBLfMu62w0y1SonRoPYdSFiFBm2G0lFWoGs4lHuY84ujYx0TWRUQOfc3dWTcAfFVNpOiMOchcWvFOqANMpA==
 
-storybook-docs-toc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/storybook-docs-toc/-/storybook-docs-toc-1.2.0.tgz#e2ad112b70aab5dd1afb22835387bba1cc03396c"
-  integrity sha512-FWMeWZE0PwG+9ijmugyqNbtuwR/78I9PGS/arQbsQcA1aiz53c0AbJouPfxthEYkqeKSHkUyDda5juYXcfrQ6w==
+storybook-docs-toc@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/storybook-docs-toc/-/storybook-docs-toc-1.3.1.tgz#b198e8c4cdc6d86462955a2b2e75eae9d9bb3624"
+  integrity sha512-J9qCt+wPYeWg8t0KSS+1buZq1km8XK1zysIdhsNErIMTH8tnQEv9SttPb7N8qOHL22evgFzGiL5D5LMDO22zXw==
   dependencies:
     tocbot "^4.12.0"
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TOC used to be shown even if there is no headings

**What is the chosen solution to this problem?**
Fix its display and add max-width on its links

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
