### PR TITLE
chore(Chromatic): run GitHub action only on label

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,12 @@
 name: Visual regression testing
 
-on: push
+on:
+  pull_request:
+    types: [labeled]
 
 jobs:
   test:
+    if: ${{ github.event.label.name == 'need visual approval' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
GH Action used to run immediately for all PR 

**What is the chosen solution to this problem?**
At least, for Chromatic, wait until the label is set on

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
