### PR TITLE
fix(icons): filter

### DIFF
--- a/src/components/IconsProvider/IconsProvider.tsx
+++ b/src/components/IconsProvider/IconsProvider.tsx
@@ -74,8 +74,7 @@ function addBundle(response: Response) {
 		return response.text().then(content => {
 			if (content.startsWith('<svg')) {
 				const container = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-				container.setAttribute('class', 'tc-iconsprovider');
-				container.setAttribute('style', 'display: none');
+				container.setAttribute('class', 'tc-iconsprovider sr-only');
 				container.setAttribute('aria-hidden', 'true');
 				container.setAttribute('focusable', 'false');
 				container.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
@@ -135,8 +134,7 @@ export function IconsProvider({ bundles = DEFAULT_BUNDLES, defaultIcons = {}, ic
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			focusable="false"
-			className="tc-iconsprovider"
-			style={{ display: 'none' }}
+			className="tc-iconsprovider sr-only"
 			ref={ref}
 		>
 			{Object.keys(iconset).map((id, index) => (

--- a/src/components/ThemeProvider/index.js
+++ b/src/components/ThemeProvider/index.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
+import { hideVisually } from 'polished';
 import 'modern-css-reset';
 
 import Toggle from '../Toggle';
@@ -34,6 +35,10 @@ const GlobalStyle = createGlobalStyle`
 	::selection {
 		color: ${tokens.colors.gray[900]};
 		background-color: ${tokens.colors.coral[100]};
+	}
+	
+	.sr-only {
+		${hideVisually()}
 	}
 `;
 

--- a/src/docs/Icons.component.js
+++ b/src/docs/Icons.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { IconGallery, IconItem } from '@storybook/components';
 import { Form, Icon, IconsProvider, ThemeProvider, tokens } from '../index';
 
@@ -6,6 +7,7 @@ export const Icons = () => {
 	const [icons, setIds] = React.useState([]);
 	const [query, setQuery] = React.useState('');
 	const [size, setSize] = React.useState(2);
+	const [filter, setFilter] = React.useState();
 	const [transform, setTransform] = React.useState('');
 	const [useCurrentColor, setUseCurrentColor] = React.useState();
 	const [currentColor, setCurrentColor] = React.useState(tokens.colors.gray[800]);
@@ -30,6 +32,7 @@ export const Icons = () => {
 	return (
 		<>
 			<ThemeProvider>
+				<ThemeProvider.GlobalStyle />
 				<IconsProvider
 					bundles={[
 						'https://statics-dev.cloud.talend.com/@talend/icons/6.7.0/dist/svg-bundle/all.svg',
@@ -74,6 +77,11 @@ export const Icons = () => {
 							onChange={() => setBorder(!border)}
 							checked={!!border}
 						/>
+						<Form.Switch
+							label="Use grayscale filter"
+							onChange={() => setFilter(!filter)}
+							checked={!!filter}
+						/>
 					</div>
 				</Form>
 			</ThemeProvider>
@@ -84,7 +92,11 @@ export const Icons = () => {
 						<IconItem key={index} name={iconName}>
 							<Icon
 								name={iconName}
-								style={{ width: size + 'rem', height: size + 'rem' }}
+								style={{
+									width: `${size}rem`,
+									height: `${size}rem`,
+									filter: filter ? "url('#talend-grayscale')" : 'none',
+								}}
 								transform={transform}
 								preserveColor={!useCurrentColor}
 								border={border}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can't use `display: none` on `<svg>` sprite for defining filters especially on Firefox

**What is the chosen solution to this problem?**
It will solve https://github.com/Talend/ui/pull/3246

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
