### PR TITLE
doc(grid): reduce gap

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,3 @@
 {
-	"extends": "@talend/scripts-config-babel/.babelrc.json",
-	"presets": ["next/babel"],
-	"plugins": [
-		[
-			"styled-components",
-			{
-				"ssr": true,
-				"displayName": true,
-				"preprocess": false
-			}
-		]
-	]
+	"extends": "@talend/scripts-config-babel/.babelrc.json"
 }

--- a/src/docs/Grid.component.js
+++ b/src/docs/Grid.component.js
@@ -2,16 +2,14 @@ import styled from 'styled-components';
 
 import tokens from '../tokens';
 
-const Grid = styled.div(
-	({ columns = 3 }) => `
+const Grid = styled.div`
 	display: grid;
-    grid-template-columns: repeat(${columns}, minmax(25rem, 1fr));
-    gap: 2rem 10rem;
+	grid-template-columns: repeat(${({ columns = 3 }) => columns}, minmax(25rem, 1fr));
+	gap: 2.5rem 5rem;
 
-    @media only screen and (max-width: ${tokens.breakpoints.m}) {
-        grid-template-columns: 1fr;
-    }
-`,
-);
+	@media only screen and (max-width: ${tokens.breakpoints.m}) {
+		grid-template-columns: 1fr;
+	}
+`;
 
 export default Grid;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Grid doc component has to a huge gap

**What is the chosen solution to this problem?**
reduce it

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
