### PR TITLE
feat(button.icon): reduce icon size

### DIFF
--- a/src/components/Button/variations/Button.icon.tsx
+++ b/src/components/Button/variations/Button.icon.tsx
@@ -17,6 +17,11 @@ const ButtonIcon: React.FC<ButtonProps> = styled(ButtonSecondary).attrs({
 	&:active {
 		background: none;
 	}
+
+	.btn__icon {
+		height: ${tokens.sizes.s};
+		width: ${tokens.sizes.s};
+	}
 `;
 
 export default ButtonIcon;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Icon Button has a too big icon

**What is the chosen solution to this problem?**
Reduce its size according to what was designed in Figma

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
