### PR TITLE
doc(Storybook): Docs tab by default

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,41 +1,94 @@
-const BrowserSyncPlugin = require('browser-sync-webpack-plugin')
+const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
 module.exports = {
 	stories: [
-		'../src/Welcome.stories.mdx',
-		'../src/GettingStarted.stories.mdx',
-		'../src/Status.stories.mdx',
-		'../src/Catalog.stories.mdx',
-		'../src/tokens/docs/*.stories.mdx',
-		'../src/content/docs/*.stories.mdx',
-		'../src/themes/docs/Light.stories.mdx',
-		'../src/themes/docs/*.stories.mdx',
-		'../src/components/**/*.stories.mdx',
-		'../src/components/**/*.stories.js',
-		'../src/templates/**/*.stories.mdx',
-		'../src/templates/**/*.stories.js',
-		'../src/pages/**/*.stories.mdx',
-		'../src/pages/**/*.stories.js',
+		'../src/Welcome.stories.@(js|tsx|mdx)',
+		'../src/GettingStarted.stories.@(js|tsx|mdx)',
+		'../src/Status.stories.@(js|tsx|mdx)',
+		'../src/Catalog.stories.@(js|tsx|mdx)',
+		'../src/tokens/docs/*.stories.@(js|tsx|mdx)',
+		'../src/content/docs/*.stories.@(js|tsx|mdx)',
+		'../src/themes/docs/Light.stories.@(js|tsx|mdx)',
+		'../src/themes/docs/*.stories.@(js|tsx|mdx)',
+		'../src/components/**/*.stories.@(js|tsx|mdx)',
+		'../src/templates/**/*.stories.@(js|tsx|mdx)',
+		'../src/pages/**/*.stories.@(js|tsx|mdx)',
 	],
+	reactOptions: {
+		fastRefresh: true,
+		strictMode: true,
+	},
 	addons: [
 		{
-			name: '@storybook/addon-essentials',
+			name: '@storybook/addon-docs',
 			options: {
-				backgrounds: false,
+				transcludeMarkdown: true,
+				sourceLoaderOptions: {
+					prettierConfig: {
+						arrowParens: 'avoid',
+						printWidth: 100,
+						singleQuote: true,
+						trailingComma: 'all',
+						semi: true,
+						useTabs: true,
+						overrides: [
+							{
+								files: '**/*.json',
+								options: {
+									tabWidth: 2,
+									useTabs: false,
+								},
+							},
+							{
+								files: '**/*.scss',
+								options: {
+									printWidth: 1000,
+								},
+							},
+						],
+					},
+				},
 			},
 		},
-		'@storybook/addon-links',
+		'@storybook/addon-controls',
 		'@storybook/addon-a11y',
+		'@storybook/addon-actions',
+		'@storybook/addon-backgrounds',
+		'@storybook/addon-viewport',
+		'@storybook/addon-toolbars',
+		'@storybook/addon-links',
 		'storybook-addon-pseudo-states',
 		'storybook-addon-mdx-embed',
 	],
+	features: {
+		postcss: false,
+	},
+	typescript: {
+		check: false,
+		checkOptions: {},
+		reactDocgen: 'react-docgen-typescript',
+		reactDocgenTypescriptOptions: {
+			shouldExtractLiteralValuesFromEnum: true,
+			propFilter: prop => {
+				if (prop.parent) {
+					// filter inherited props
+					return !prop.parent.fileName.includes('node_modules');
+				}
+
+				// filter inherited styled-components props
+				return !['theme', 'as', 'forwardedAs', 'ref'].includes(prop.name);
+			},
+		},
+	},
 	webpackFinal: async config => {
 		config.entry.unshift('core-js');
-		config.plugins.push(new BrowserSyncPlugin({
-			host: 'localhost',
-			port: 3002,
-			proxy: 'http://localhost:6006/'
-		}));
+		config.plugins.push(
+			new BrowserSyncPlugin({
+				host: 'localhost',
+				port: 3002,
+				proxy: 'http://localhost:6006/',
+			}),
+		);
 		return config;
 	},
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build:lib:umd:min": "talend-scripts build:lib:umd --prod",
     "start": "npm run storybook",
     "test": "talend-scripts test",
-    "storybook": "BROWSER=none start-storybook -s static -p 6006",
-    "build-storybook": "build-storybook -s static",
+    "storybook": "BROWSER=none start-storybook -s static -p 6006 --docs",
+    "build-storybook": "build-storybook -s static --docs",
     "lint:es": "talend-scripts lint:es"
   },
   "repository": {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The default behavior while navigating trough Storybook is set on `Canvas` tab, which it's not really convenient!

**What is the chosen solution to this problem?**
Pass `--docs` while building Storybook

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
