### PR TITLE
chore(changeset): postinstall script

### DIFF
--- a/.changeset/eleven-walls-crash.md
+++ b/.changeset/eleven-walls-crash.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Post Install script was not defined and components were not released

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
+    "postinstall": "npm run build",
     "release": "yarn changeset publish",
     "build": "npm run build:lib && npm run build:lib:umd && npm run build:lib:umd:min",
     "build:lib": "talend-scripts build:ts:lib",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`postinstall` script was not in the package.json and changeset doesn't release components

**What is the chosen solution to this problem?**
Add `postinstall` script

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
