### PR TITLE
chore: cleanup release

### DIFF
--- a/.changeset/fast-birds-learn.md
+++ b/.changeset/fast-birds-learn.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Cleanup release content

--- a/.npmignore
+++ b/.npmignore
@@ -3,10 +3,10 @@
 .next
 .storybook
 .test-cache
-
+.changeset
 coverage
-cypress/screenshots
-cypress/videos
+/cypress
+/pages
 node_modules
 out
 src

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Talend/design-system/issues"
   },
-  "homepage": "https://github.com/Talend/design-system#readme",
+  "homepage": "https://design.talend.com/",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "classnames": "^2.2.6",
     "i18next": "^20.1.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

https://unpkg.com/browse/@talend/design-system@1.1.2/

contains and should not:
* .changeset folder
* pages
* cypress

At Talend we use apache-2.0 licence

visibility of the package is private.

**What is the chosen solution to this problem?**

* switch to access public (all previous release also using npm cli)
* add unwanted content into npmignore
* update license

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
