### PR TITLE
chore(Storybook): FigmaImage error management

### DIFF
--- a/src/docs/FigmaImage.js
+++ b/src/docs/FigmaImage.js
@@ -73,7 +73,13 @@ const FigmaImage = ({ src, alt = '', ...rest }) => {
 			.fileImages(projectId, {
 				ids: [nodeId],
 			})
-			.then(({ data }) => setData(data));
+			.then(({ data }) => setData(data))
+			.catch(reason => {
+				console.error(
+					'[FigmaImage] Verify that you use STORYBOOK_FIGMA_ACCESS_TOKEN correctly!',
+					reason,
+				);
+			});
 	}, [src]);
 
 	if (!figma.isConfigured) {

--- a/static/sw.js
+++ b/static/sw.js
@@ -12,22 +12,26 @@ self.addEventListener('fetch', event => {
 				cache =>
 					// eslint-disable-next-line no-console
 					console.debug(`[${CACHE_NAME}] Get Figma asset from cache`, event.request.url) ||
-					cache.match(event.request).then(match => match || fetch(event.request)),
+					cache
+						.match(event.request)
+						.then(match => match || fetch(event.request).catch(reason => console.error(reason))),
 			),
 		);
 
 		event.waitUntil(
 			caches.open(CACHE_NAME).then(cache =>
-				fetch(event.request).then(response =>
-					cache.put(event.request, response.clone()).then(
-						() =>
-							// eslint-disable-next-line no-console
-							console.debug(
-								`[${CACHE_NAME}] Async get Figma assets from network`,
-								event.request.url,
-							) || response,
-					),
-				),
+				fetch(event.request)
+					.then(response =>
+						cache.put(event.request, response.clone()).then(
+							() =>
+								// eslint-disable-next-line no-console
+								console.debug(
+									`[${CACHE_NAME}] Async get Figma assets from network`,
+									event.request.url,
+								) || response,
+						),
+					)
+					.catch(reason => console.error(reason)),
 			),
 		);
 	}

--- a/static/sw.js
+++ b/static/sw.js
@@ -12,9 +12,7 @@ self.addEventListener('fetch', event => {
 				cache =>
 					// eslint-disable-next-line no-console
 					console.debug(`[${CACHE_NAME}] Get Figma asset from cache`, event.request.url) ||
-					cache
-						.match(event.request)
-						.then(match => match || fetch(event.request)),
+					cache.match(event.request).then(match => match || fetch(event.request)),
 			),
 		);
 

--- a/static/sw.js
+++ b/static/sw.js
@@ -20,18 +20,16 @@ self.addEventListener('fetch', event => {
 
 		event.waitUntil(
 			caches.open(CACHE_NAME).then(cache =>
-				fetch(event.request)
-					.then(response =>
-						cache.put(event.request, response.clone()).then(
-							() =>
-								// eslint-disable-next-line no-console
-								console.debug(
-									`[${CACHE_NAME}] Async get Figma assets from network`,
-									event.request.url,
-								) || response,
-						),
-					)
-					.catch(reason => console.error(reason)),
+				fetch(event.request).then(response =>
+					cache.put(event.request, response.clone()).then(
+						() =>
+							// eslint-disable-next-line no-console
+							console.debug(
+								`[${CACHE_NAME}] Async get Figma assets from network`,
+								event.request.url,
+							) || response,
+					),
+				),
 			),
 		);
 	}

--- a/static/sw.js
+++ b/static/sw.js
@@ -14,7 +14,7 @@ self.addEventListener('fetch', event => {
 					console.debug(`[${CACHE_NAME}] Get Figma asset from cache`, event.request.url) ||
 					cache
 						.match(event.request)
-						.then(match => match || fetch(event.request).catch(reason => console.error(reason))),
+						.then(match => match || fetch(event.request)),
 			),
 		);
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If you don't use a Figma token via the env var `STORYBOOK_FIGMA_ACCESS_TOKEN`, it can fail with a fullscreen error.

**What is the chosen solution to this problem?**
Add errors management to not be annoying.

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
