### PR TITLE
fix(components): Inline Message

### DIFF
--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -7,40 +7,40 @@ export type InlineMessageProps = {
 	withBackground?: boolean;
 };
 
-export const InlineMessage = styled.div<InlineMessageProps>(
-	({ small, withBackground, theme }) => `
-	display: ${withBackground ? 'inline-flex' : 'inline'};
-	margin-right: 0.5rem;
-	${
-		withBackground
-			? `padding: ${tokens.space.xs} ${tokens.space.s} ${tokens.space.xs} ${tokens.space.xl};`
-			: ''
-	}
+export const InlineMessage = styled.div<InlineMessageProps>`
+	display: ${({ withBackground }) => (withBackground ? 'inline-block' : 'inline')};
+	margin-bottom: ${tokens.space.m};
+	${({ withBackground }) =>
+		withBackground ? `padding: ${tokens.space.xs} ${tokens.space.s};` : ''}
 	font-family: ${tokens.fonts.sansSerif};
-	${small ? `font-size: ${tokens.fontSizes.small};` : ''}
+	${({ small }) => (small ? `font-size: ${tokens.fontSizes.small};` : '')}
+	border-radius: ${tokens.radii.inputBorderRadius};
 
-	p {
-		margin: 0;
-	}
-	
 	.inline-message__icon {
+		vertical-align: middle;
 		padding-right: ${tokens.space.xs};
-		${withBackground ? `margin-left: -${tokens.space.l}; ` : ''}
-		    
+
 		svg {
-	  		margin-bottom: ${small ? '-0.1rem' : '-0.2rem'};
-			height: ${small ? tokens.sizes.s : tokens.sizes.m};
-			width: ${small ? tokens.sizes.s : tokens.sizes.m};
+			height: ${({ small }) => (small ? tokens.sizes.s : tokens.sizes.l)};
+			width: ${({ small }) => (small ? tokens.sizes.s : tokens.sizes.l)};
 		}
 
 		path {
 			fill: currentColor;
 		}
 	}
-	
+
+	p {
+		display: inline-block;
+	}
+
+	.inline-message__title {
+		font-weight: bold;
+	}
+
 	.inline-message__title,
 	.inline-message__description {
-		color: ${withBackground ? tokens.colors.gray[900] : theme.colors.textColor};
+		color: ${({ withBackground, theme }) =>
+			withBackground ? tokens.colors.gray[900] : theme.colors.textColor};
 	}
-`,
-);
+`;

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -8,7 +8,7 @@ export type InlineMessageProps = {
 };
 
 export const InlineMessage = styled.div<InlineMessageProps>`
-	display: ${({ withBackground }) => (withBackground ? 'inline-block' : 'inline')};
+	display: ${({ withBackground }) => (withBackground ? 'inline-flex' : 'inline')};
 	margin-bottom: ${tokens.space.m};
 	${({ withBackground }) =>
 		withBackground ? `padding: ${tokens.space.xs} ${tokens.space.s};` : ''}
@@ -17,12 +17,12 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	border-radius: ${tokens.radii.inputBorderRadius};
 
 	.inline-message__icon {
-		vertical-align: middle;
 		padding-right: ${tokens.space.xs};
 
 		svg {
 			height: ${({ small }) => (small ? tokens.sizes.s : tokens.sizes.l)};
 			width: ${({ small }) => (small ? tokens.sizes.s : tokens.sizes.l)};
+			vertical-align: middle;
 		}
 
 		path {
@@ -31,7 +31,7 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	}
 
 	p {
-		display: inline-block;
+		display: inline;
 	}
 
 	.inline-message__title {
@@ -42,5 +42,11 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	.inline-message__description {
 		color: ${({ withBackground, theme }) =>
 			withBackground ? tokens.colors.gray[900] : theme.colors.textColor};
+	}
+
+	.inline-message__title,
+	.inline-message__description,
+	.inline-message__link {
+		vertical-align: middle;
 	}
 `;

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -35,7 +35,7 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	}
 
 	.inline-message__title {
-		font-weight: bold;
+		font-weight: ${tokens.fontWeights.semiBold};
 	}
 
 	.inline-message__title,

--- a/src/components/InlineMessage/InlineMessage.tsx
+++ b/src/components/InlineMessage/InlineMessage.tsx
@@ -35,17 +35,15 @@ const InlineMessage = React.forwardRef(
 				className={`inline-message ${className || ''}`}
 				ref={ref}
 			>
+				{icon && (
+					<span className="inline-message__icon">
+						<Icon name={icon} />
+					</span>
+				)}
 				<p>
-					{(icon || title) && (
+					{title && (
 						<>
-							<span className="inline-message__icon">
-								<Icon name={icon} />
-							</span>
-							{title && (
-								<>
-									<span className="inline-message__title">{title}</span>{' '}
-								</>
-							)}
+							<span className="inline-message__title">{title}</span>{' '}
 						</>
 					)}
 					{description && (

--- a/src/components/InlineMessage/docs/InlineMessage.stories.mdx
+++ b/src/components/InlineMessage/docs/InlineMessage.stories.mdx
@@ -26,7 +26,7 @@ It can be additional information related to system status, it can be a required 
 ### Icons
 
 <IconGallery>
-	{['talend-cross', 'talend-warning', 'talend-check', 'talend-info-circle'].map((iconName, index) => (
+	{['talend-error', 'talend-warning', 'talend-check', 'talend-info-circle'].map((iconName, index) => (
 		<IconItem key={index} name={iconName}>
 			<Icon name={iconName} />
 		</IconItem>

--- a/src/components/InlineMessage/variations/InlineMessage.destructive.tsx
+++ b/src/components/InlineMessage/variations/InlineMessage.destructive.tsx
@@ -4,7 +4,7 @@ import { tint } from 'polished';
 import InlineMessage from '../InlineMessage';
 
 const InlineMessageDestructive = styled(InlineMessage).attrs({
-	icon: 'talend-cross-circle',
+	icon: 'talend-error',
 })(
 	({ withBackground, theme }) => `
 	color: ${theme.colors.destructiveColor[500]};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`InlineMessage.Destructive` uses the wrong icon and `Inline Message` style can be simplified
 
**What is the chosen solution to this problem?**
Change  the  icon and simplify its style

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
