### PR TITLE
fix(Link): underline

### DIFF
--- a/.changeset/new-icons-listen.md
+++ b/.changeset/new-icons-listen.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Links can have double underline

--- a/src/components/Link/Link.spec.tsx
+++ b/src/components/Link/Link.spec.tsx
@@ -7,7 +7,7 @@ import Link from './';
 context('<Link />', () => {
 	it('should render', () => {
 		cy.mount(
-			<Link iconBefore="information" href="https://help.talend.com">
+			<Link iconBefore="information" target="_blank" href="https://help.talend.com">
 				Help
 			</Link>,
 		);

--- a/src/components/Link/Link.spec.tsx
+++ b/src/components/Link/Link.spec.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import Link from './';
+import Link from '.';
 
 context('<Link />', () => {
 	it('should render', () => {

--- a/src/components/Link/Link.style.ts
+++ b/src/components/Link/Link.style.ts
@@ -5,8 +5,15 @@ import tokens from '../../tokens';
 export const Link = styled.a`
 	font-family: ${tokens.fonts.sansSerif};
 	color: var(--t-link-color, ${({ theme }) => theme.colors?.linkColor});
-	text-decoration: none;
 	border-bottom-color: currentColor;
+
+	&,
+	&:hover,
+	&:active,
+	&:focus,
+	&:visited {
+		text-decoration: none;
+	}
 
 	.link__text {
 		border-bottom: 0.1rem solid transparent;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -45,8 +45,8 @@ const Link = React.forwardRef(
 		const getTitle = React.useCallback(() => {
 			if (disabled && title) return `${title} (this link is disabled)`;
 			if (disabled) return 'This link is disabled';
-			if (isExternal && title) return `${title} (open in a new tab)`;
-			if (isExternal) return 'Open in a new tab';
+			if (isExternal && isBlank && title) return `${title} (open in a new tab)`;
+			if (isExternal && isBlank) return 'Open in a new tab';
 			return title;
 		}, [disabled, title, isExternal]);
 

--- a/src/components/Link/docs/Link.stories.mdx
+++ b/src/components/Link/docs/Link.stories.mdx
@@ -30,15 +30,11 @@ Still need to be convinced? Please, take the time to read [this article written 
 	<Story name="default">
 		<Link href="#">Link example</Link>
 	</Story>
-	<Story name="hover">
-		<WithSelector selector=":hover">
-			<Link href="#">Link example</Link>
-		</WithSelector>
+	<Story name="hover" decorators={[WithSelector.decorator(':hover')]}>
+		<Link href="#">Link example</Link>
 	</Story>
-	<Story name="active">
-		<WithSelector selector=":active">
-			<Link href="#">Link example</Link>
-		</WithSelector>
+	<Story name="active" decorators={[WithSelector.decorator(':active')]}>
+		<Link href="#">Link example</Link>
 	</Story>
 </Canvas>
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Link can have double underline

**What is the chosen solution to this problem?**
Get rid of the text decoration

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
