### PR TITLE
feat(CTA): keep style when using as

### DIFF
--- a/.changeset/rude-gifts-tease.md
+++ b/.changeset/rude-gifts-tease.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+CTA should keep their style if using as

--- a/src/Catalog.stories.mdx
+++ b/src/Catalog.stories.mdx
@@ -123,6 +123,26 @@ import { Button, Dropdown, Form, Icon, InlineMessage, Link, Popover, Tag, Toggle
 	</Story>
 </Canvas>
 
+## As button, As link
+
+<Canvas>
+	<Story name="As">
+		<Link as="button">Link as button</Link>
+		<Button.Primary as="a" href="#">
+			Primary button as link
+		</Button.Primary>
+		<Button.Destructive as="a" href="#">
+			Destructive button as link
+		</Button.Destructive>
+		<Button.Secondary as="a" href="#">
+			Secondary button as link
+		</Button.Secondary>
+		<Button.Tertiary as="a" href="#">
+			Tertiary button as link
+		</Button.Tertiary>
+	</Story>
+</Canvas>
+
 ## Forms
 
 <Canvas>

--- a/src/components/Button/variations/Button.base.tsx
+++ b/src/components/Button/variations/Button.base.tsx
@@ -4,14 +4,23 @@ import Button, { ButtonProps } from '../Button';
 import tokens from '../../../tokens';
 
 const ButtonBase: React.FC<ButtonProps> = styled(Button)`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	padding: ${tokens.space.none} ${tokens.space.m};
 	min-height: ${tokens.sizes.xxl};
 	border: ${tokens.borders.normal};
 	border-radius: ${tokens.radii.rectRadius};
 	transition: ${tokens.transitions.fast};
-	color: var(--t-button-color, ${({ theme }) => theme.colors?.textColor});
-	background: var(--t-button-background-color);
-	border-color: var(--t-button-border-color);
+
+	&,
+	&:hover,
+	&:focus {
+		color: var(--t-button-color, ${({ theme }) => theme.colors?.textColor});
+		background: var(--t-button-background-color);
+		border-color: var(--t-button-border-color);
+		text-decoration: none;
+	}
 
 	&[aria-busy='true'],
 	&[aria-disabled='true'] {

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -32,6 +32,7 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 
 	p {
 		display: inline;
+		margin: 0;
 	}
 
 	.inline-message__title {

--- a/src/components/Link/Link.style.ts
+++ b/src/components/Link/Link.style.ts
@@ -5,7 +5,10 @@ import tokens from '../../tokens';
 export const Link = styled.a`
 	font-family: ${tokens.fonts.sansSerif};
 	color: var(--t-link-color, ${({ theme }) => theme.colors?.linkColor});
+	background: none;
+	border: none;
 	border-bottom-color: currentColor;
+	cursor: pointer;
 
 	&,
 	&:hover,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Can't use `Link` as "button" or `Button` as "a"

**What is the chosen solution to this problem?**
Adapt style to match new element

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
