### PR TITLE
fix(components): stepper progress bar style

### DIFF
--- a/.changeset/hungry-needles-drum.md
+++ b/.changeset/hungry-needles-drum.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Using bootstrap, the progress bar of the stepper is darker

--- a/src/components/Stepper/Progress/variations/Progress.horizontal.ts
+++ b/src/components/Stepper/Progress/variations/Progress.horizontal.ts
@@ -10,7 +10,7 @@ const ProgressHorizontal = styled(Progress).attrs({
 	right: 10rem;
 	left: 10rem;
 	height: 0.2rem;
-	background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3cline x1='0' y1='0' x2='100%25' y2='0' fill='none' stroke='%23d2d2d2' stroke-width='4' stroke-dasharray='2%2c6'/%3e%3c/svg%3e");
+	background: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3cline x1='0' y1='0' x2='100%25' y2='0' fill='none' stroke='%23d2d2d2' stroke-width='4' stroke-dasharray='2%2c6'/%3e%3c/svg%3e");
 
 	div {
 		top: 0;

--- a/src/components/Stepper/Progress/variations/Progress.vertical.ts
+++ b/src/components/Stepper/Progress/variations/Progress.vertical.ts
@@ -10,7 +10,7 @@ const ProgressVertical = styled(Progress).attrs({
 	right: 0.9rem;
 	bottom: 0.1rem;
 	width: 0.2rem;
-	background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3cline x1='0' y1='0' x2='0' y2='100%25' fill='none' stroke='%23d2d2d2' stroke-width='4' stroke-dasharray='2%2c6'/%3e%3c/svg%3e");
+	background: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3cline x1='0' y1='0' x2='0' y2='100%25' fill='none' stroke='%23d2d2d2' stroke-width='4' stroke-dasharray='2%2c6'/%3e%3c/svg%3e");
 
 	div {
 		width: 0.2rem;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Progress bar style is messed up using Bootstrap stylesheet

**What is the chosen solution to this problem?**
Increase style weight

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
