### PR TITLE
fix(InlineMessage): default colors should inherit

### DIFF
--- a/.changeset/calm-chairs-wash.md
+++ b/.changeset/calm-chairs-wash.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+InlineMessage default colors should inherit

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -16,7 +16,11 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	${({ small }) => (small ? `font-size: ${tokens.fontSizes?.small};` : '')}
 	border-radius: ${tokens.radii?.inputBorderRadius};
 
-	color: var(--t-inline-message-icon-color, ${({ theme }) => theme.colors?.textColor});
+	color: var(
+		--t-inline-message-icon-color,
+		${({ theme, withBackground }) =>
+			withBackground ? theme.colors?.backgroundColor : theme.colors?.textColor}
+	);
 	background: var(--t-inline-message-background, transparent);
 	box-shadow: var(--t-inline-message-box-shadow, transparent);
 
@@ -26,12 +30,16 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 		svg {
 			height: ${({ small }) => (small ? tokens.sizes?.s : tokens.sizes?.l)};
 			width: ${({ small }) => (small ? tokens.sizes?.s : tokens.sizes?.l)};
-			vertical-align: middle;
 		}
 
 		path {
 			fill: currentColor;
 		}
+	}
+
+	.inline-message__icon,
+	p {
+		vertical-align: middle;
 	}
 
 	p {
@@ -46,11 +54,5 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	.inline-message__title,
 	.inline-message__description {
 		color: var(--t-inline-message-color, ${({ theme }) => theme.colors?.textColor});
-	}
-
-	.inline-message__title,
-	.inline-message__description,
-	.inline-message__link {
-		vertical-align: middle;
 	}
 `;

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -45,7 +45,7 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 
 	.inline-message__title,
 	.inline-message__description {
-		color: var(--t-inline-message-color, ${({ theme }) => theme.colors?.textColor || 'initial'});
+		color: var(--t-inline-message-color, ${({ theme }) => theme.colors?.textColor});
 	}
 
 	.inline-message__title,

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -16,15 +16,9 @@ export const InlineMessage = styled.div<InlineMessageProps>`
 	${({ small }) => (small ? `font-size: ${tokens.fontSizes?.small};` : '')}
 	border-radius: ${tokens.radii?.inputBorderRadius};
 
-	color: var(--t-inline-message-icon-color, ${({ theme }) => theme.colors?.textColor || 'initial'});
-	background: var(
-		--t-inline-message-background,
-		${({ theme }) => theme.colors?.backgroundColor || 'transparent'}
-	);
-	box-shadow: var(
-		--t-inline-message-box-shadow,
-		${({ theme }) => theme.colors?.backgroundColor || 'transparent'}
-	);
+	color: var(--t-inline-message-icon-color, ${({ theme }) => theme.colors?.textColor});
+	background: var(--t-inline-message-background, transparent);
+	box-shadow: var(--t-inline-message-box-shadow, transparent);
 
 	.inline-message__icon {
 		padding-right: ${tokens.space?.xs};

--- a/src/components/InlineMessage/InlineMessage.tsx
+++ b/src/components/InlineMessage/InlineMessage.tsx
@@ -1,24 +1,27 @@
 import React, { PropsWithChildren } from 'react';
+import { StyledProps } from 'styled-components';
 import { IconName } from '@talend/icons';
 
 import { Icon } from '../Icon/Icon';
 
 import * as S from './InlineMessage.style';
+import { light } from '../../themes';
 
-export type InlineMessageProps = PropsWithChildren<any> & {
-	/** The icon element to display */
-	icon: IconName;
-	/** The title of the message */
-	title?: string;
-	/** The content of the message */
-	description: string;
-	/** Size variant */
-	small: boolean;
-	/** Link element at the end */
-	link?: React.ReactElement;
-	/** If it is an inline message or a block with a background */
-	withBackground?: boolean;
-};
+export type InlineMessageProps = PropsWithChildren<any> &
+	StyledProps<any> & {
+		/** The icon element to display */
+		icon: IconName;
+		/** The title of the message */
+		title?: string;
+		/** The content of the message */
+		description: string;
+		/** Size variant */
+		small: boolean;
+		/** Link element at the end */
+		link?: React.ReactElement;
+		/** If it is an inline message or a block with a background */
+		withBackground?: boolean;
+	};
 
 /**
  Inline message highlights information necessary to display for the user in many different contexts.
@@ -26,36 +29,52 @@ export type InlineMessageProps = PropsWithChildren<any> & {
  @link https://inclusive-components.design/notifications
  * */
 const InlineMessage = React.forwardRef(
-	({ icon, title, description, link, className = '', ...rest }: InlineMessageProps, ref) => {
-		return (
-			<S.InlineMessage
-				role="status"
-				aria-live="polite"
-				{...rest}
-				className={`inline-message ${className || ''}`}
-				ref={ref}
-			>
-				{icon && (
-					<span className="inline-message__icon">
-						<Icon name={icon} />
+	(
+		{
+			icon,
+			title,
+			description,
+			link,
+			className = '',
+			withBackground,
+			theme,
+			...rest
+		}: InlineMessageProps,
+		ref,
+	) => (
+		<S.InlineMessage
+			role="status"
+			aria-live="polite"
+			{...rest}
+			className={`inline-message ${className || ''}`}
+			theme={withBackground ? light : theme}
+			withBackground={withBackground}
+			ref={ref}
+		>
+			{icon && (
+				<span className="inline-message__icon">
+					<Icon name={icon} />
+				</span>
+			)}
+			<p>
+				{title && (
+					<>
+						<span className="inline-message__title">{title}</span>{' '}
+					</>
+				)}
+				{description && (
+					<>
+						<span className="inline-message__description">{description}</span>{' '}
+					</>
+				)}
+				{link && (
+					<span className="inline-message__link">
+						{React.cloneElement(link, { theme: withBackground ? light : theme })}
 					</span>
 				)}
-				<p>
-					{title && (
-						<>
-							<span className="inline-message__title">{title}</span>{' '}
-						</>
-					)}
-					{description && (
-						<>
-							<span className="inline-message__description">{description}</span>{' '}
-						</>
-					)}
-					{link && <span className="inline-message__link">{link}</span>}
-				</p>
-			</S.InlineMessage>
-		);
-	},
+			</p>
+		</S.InlineMessage>
+	),
 );
 
 export default InlineMessage;

--- a/src/components/InlineMessage/docs/InlineMessage.stories.mdx
+++ b/src/components/InlineMessage/docs/InlineMessage.stories.mdx
@@ -1,9 +1,8 @@
 import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
-import { ColorPalette, ColorItem, IconItem, IconGallery } from '@storybook/components';
+import { IconItem, IconGallery } from '@storybook/components';
 import { FigmaImage, Use } from '../../../docs';
 import * as Stories from '../InlineMessage.stories';
 
-import tokens from '../../../tokens';
 import { Icon } from '../../Icon';
 import InlineMessage from '../';
 
@@ -144,7 +143,7 @@ Error messages should tell why there was a problem and what could be done to res
 			title: 'A title',
 			description: 'with a description',
 			small: false,
-			withBackground: true,
+			withBackground: false,
 		}}
 		argTypes={{
 			variant: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
InlineMessage default CSS properties were  hardcoded 

**What is the chosen solution to this problem?**
Inherit instead

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
