### PR TITLE
fix(Forms): focus outline should not be visible using mouse

### DIFF
--- a/.changeset/silent-windows-dress.md
+++ b/.changeset/silent-windows-dress.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Focus outline should not be visible using mouse

--- a/src/components/Form/Field/Field.style.ts
+++ b/src/components/Form/Field/Field.style.ts
@@ -159,6 +159,15 @@ export const InlineStyle = styled.div.attrs<{ readOnly: boolean; checked: boolea
 	}
 
 	input:focus:not(:disabled) + span {
+		// Safari
+		outline: 0.3rem solid ${({ theme }) => theme.colors.focusColor[500]};
+	}
+	input:focus:not(:focus-visible):not(:disabled) + span {
+		// Reset for others than Safari
+		outline: none;
+	}
+	input:focus-visible:not(:disabled) + span {
+		// For others than Safari
 		outline: 0.3rem solid ${({ theme }) => theme.colors.focusColor[500]};
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Focus outline was visible every time

**What is the chosen solution to this problem?**
Show it only when using the keyboard

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
