### PR TITLE
fix(Stepper): Progress bar classnames need to be more precise

### DIFF
--- a/src/components/Stepper/Progress/Progress.style.ts
+++ b/src/components/Stepper/Progress/Progress.style.ts
@@ -5,7 +5,7 @@ const progress = keyframes`
 `;
 
 export const Progress = styled.div.attrs({
-	className: 'progress-bar',
+	className: 'c-stepper__progress-bar',
 })`
 	position: absolute;
 

--- a/src/components/Stepper/Progress/variations/Progress.horizontal.ts
+++ b/src/components/Stepper/Progress/variations/Progress.horizontal.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Progress from '../Progress';
 
 const ProgressHorizontal = styled(Progress).attrs({
-	className: 'progress-bar--horizontal',
+	className: 'c-stepper__progress-bar--horizontal',
 	orientation: 'horizontal',
 })`
 	top: 0.9rem;

--- a/src/components/Stepper/Progress/variations/Progress.vertical.ts
+++ b/src/components/Stepper/Progress/variations/Progress.vertical.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Progress from '../Progress';
 
 const ProgressVertical = styled(Progress).attrs({
-	className: 'progress-bar--vertical',
+	className: 'c-stepper__progress-bar--vertical',
 	orientation: 'vertical',
 })`
 	top: 0.1rem;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The progress bar for the stepper has really common class name which can be used in the project

**What is the chosen solution to this problem?**
Scope it

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
