### PR TITLE
fix(Templates): nav width

### DIFF
--- a/.changeset/clever-flowers-argue.md
+++ b/.changeset/clever-flowers-argue.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Adjust the nav width when templates display a menu

--- a/src/components/Layout/Layout.style.ts
+++ b/src/components/Layout/Layout.style.ts
@@ -32,8 +32,9 @@ export const LayoutGroup = styled.div<LayoutProps>`
 
 export const Nav = styled.nav.attrs({
 	role: 'navigation',
-})<{ isNavCollapsed: boolean }>`
+})`
 	display: flex;
+	flex-direction: column;
 `;
 
 export const Main = styled.main.attrs({

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -29,7 +29,7 @@ const Layout: React.FC<LayoutProps> = ({
 				{header && <S.Header className="layout__header">{header}</S.Header>}
 				{nav || aside ? (
 					<S.LayoutGroup className="layout__group">
-						{nav}
+						<S.Nav>{nav}</S.Nav>
 						{aside && asideVisibility ? (
 							<S.AsideOverlay
 								className="layout__overlay"

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -11,12 +11,12 @@ export const Nav = styled.nav.attrs({
 })<{ isCollapsed: boolean; variant: string }>`
 	position: relative;
 	flex: 0 1 auto;
+	min-width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : '20rem')};
 	max-width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : 'auto')};
 	min-height: 100%;
-	width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : '20rem')};
 	color: ${tokens.colors.gray[0]};
 	background: ${tokens.colors.twilight.backgroundImage};
-	transition: flex-basis ${tokens.transitions.normal};
+	transition: min-width ${tokens.transitions.normal}, max-width ${tokens.transitions.normal};
 	overflow: hidden;
 
 	${({ isCollapsed }) =>

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -12,7 +12,7 @@ export const Nav = styled.nav.attrs({
 	position: relative;
 	flex: 0 1 auto;
 	min-width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : '20rem')};
-	max-width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : 'auto')};
+	max-width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : '40rem')};
 	min-height: 100%;
 	color: ${tokens.colors.gray[0]};
 	background: ${tokens.colors.twilight.backgroundImage};

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -10,9 +10,10 @@ export const Nav = styled.nav.attrs({
 	className: 'c-menu',
 })<{ isCollapsed: boolean; variant: string }>`
 	position: relative;
-	flex: 0 1 ${({ isCollapsed }) => (isCollapsed ? '6rem' : '20rem')};
+	flex: 0 1 auto;
 	max-width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : 'auto')};
 	min-height: 100%;
+	width: ${({ isCollapsed }) => (isCollapsed ? '6rem' : '20rem')};
 	color: ${tokens.colors.gray[0]};
 	background: ${tokens.colors.twilight.backgroundImage};
 	transition: flex-basis ${tokens.transitions.normal};

--- a/src/templates/List.tsx
+++ b/src/templates/List.tsx
@@ -3,9 +3,9 @@ import React, { PropsWithChildren } from 'react';
 import Layout from '../components/Layout';
 
 export type ListProps = PropsWithChildren<any> & {
-	header?: React.ReactElement<any>;
-	nav?: React.ReactElement<any>;
-	aside?: React.ReactElement<any>;
+	header?: React.ReactElement;
+	nav?: React.ReactElement;
+	aside?: React.ReactElement;
 };
 
 const List: React.FC<ListProps> = ({ header, nav, children, aside }: ListProps) => (

--- a/src/templates/docs/Templates.stories.js
+++ b/src/templates/docs/Templates.stories.js
@@ -25,7 +25,7 @@ const Box = styled.div`
 
 const args = {
 	header: <Box>Header</Box>,
-	nav: <Box>Nav</Box>,
+	nav: <Box style={{ width: '20rem' }}>Nav</Box>,
 	title: <Box>Title</Box>,
 	footer: <Box>Footer</Box>,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Nav width in templates was not managed correctly

**What is the chosen solution to this problem?**
Adjust the nav width when templates display a menu

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
