### PR TITLE
fix(templates): Step with dark mode

### DIFF
--- a/.changeset/little-rocks-jam.md
+++ b/.changeset/little-rocks-jam.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Be able to use dark mode using template Step

--- a/src/templates/Step.tsx
+++ b/src/templates/Step.tsx
@@ -10,22 +10,24 @@ export type StepByStepProps = PropsWithChildren<any> & {
 	stepper?: StepperProps;
 };
 
-const Box = styled.div<{ background?: string; width?: number }>`
-	width: ${({ width }) => (width ? 'auto' : '100%')};
-	background: ${({ background }) => background || tokens.colors.transparent};
-`;
+const Box = styled.div<{ width?: number }>``;
 
 const Row = styled(Box)`
 	display: flex;
 	flex: ${({ width }) => (width ? 0 : 1)};
 	flex-basis: ${({ width }) => width || 'auto'};
+	background: ${({ theme }) => theme.colors.backgroundColor};
+`;
+
+const Col = styled(Box)`
+	width: ${({ width }) => (width ? 'auto' : '100%')};
 `;
 
 const Step: React.FC<StepByStepProps> = ({ header, children, stepper }: StepByStepProps) => (
 	<Layout hasScreenHeight header={header}>
-		<Row background={tokens.colors.gray[0]}>
-			<Box width={25}>{stepper}</Box>
-			<Box>{children}</Box>
+		<Row>
+			<Col width={25}>{stepper}</Col>
+			<Col>{children}</Col>
 		</Row>
 	</Layout>
 );


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Step template was not working with dark mode

**What is the chosen solution to this problem?**
Use theme instead to be able to switch 

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
