### PR TITLE
chore(Tests): @storybook/testing-react

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from '@cypress/react';
-import '@applitools/eyes-cypress/commands';
 import { setGlobalConfig } from '@storybook/testing-react';
 import * as globalStorybookConfig from '../../.storybook/preview'; // path of your preview.js file
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { mount } from '@cypress/react';
+import '@applitools/eyes-cypress/commands';
+import { setGlobalConfig } from '@storybook/testing-react';
+import * as globalStorybookConfig from '../../.storybook/preview'; // path of your preview.js file
 
-import ThemeProvider from '../../src/components/ThemeProvider';
+setGlobalConfig(globalStorybookConfig);
 
-Cypress.Commands.add('mount', jsx => {
-	mount(React.createElement(ThemeProvider, null, jsx));
+Cypress.Commands.add('mount', reactElement => {
+	mount(reactElement);
 });

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@storybook/addon-links": "6.4.0-alpha.30",
     "@storybook/addons": "6.4.0-alpha.30",
     "@storybook/react": "6.4.0-alpha.30",
+    "@storybook/testing-react": "1.0.0--canary.46.4a6c010.0",
     "@storybook/theming": "6.4.0-alpha.30",
     "@svgr/webpack": "^5.5.0",
     "@talend/icons": "^6.36.0",

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -1,29 +1,12 @@
 /// <reference types="cypress" />
 
 import React from 'react';
+import { composeStories } from '@storybook/testing-react';
 
-import { ButtonProps } from './Button';
-import Button from './';
-import Tooltip from '../Tooltip';
+import Button from '.';
+import * as Stories from './Button.stories';
 
-export const LoadingButton = (props: ButtonProps) => {
-	const [loading, isLoading] = React.useState(false);
-	return (
-		<Tooltip title="Relevant description of the basic button">
-			<Button.Primary
-				icon="talend-check"
-				loading={loading}
-				onClick={() => {
-					isLoading(true);
-					setTimeout(() => isLoading(false), 3000);
-				}}
-				{...props}
-			>
-				Async call to action
-			</Button.Primary>
-		</Tooltip>
-	);
-};
+const { Loading } = composeStories(Stories);
 
 context('<Button />', () => {
 	describe('default state', () => {
@@ -35,21 +18,16 @@ context('<Button />', () => {
 
 	describe('loading state', () => {
 		it('should load', () => {
-			cy.mount(<LoadingButton />);
+			cy.mount(<Loading />);
 			cy.get('.btn')
 				.should('have.attr', 'aria-busy', 'false')
 				.click()
 				.should('have.attr', 'aria-busy', 'true');
-			cy.get('.btn')
-				.should('have.attr', 'aria-busy', 'false');
+			cy.get('.btn').should('have.attr', 'aria-busy', 'false');
 		});
 
 		it('should have a tooltip', () => {
-			cy.mount(
-				<Tooltip title="Relevant description of the basic button">
-					<Button>Async</Button>
-				</Tooltip>,
-			);
+			cy.mount(<Loading />);
 			cy.get('.btn')
 				.focus()
 				.should('have.attr', 'aria-describedby')

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import Button from '.';
+import Tooltip from '../Tooltip';
+
+export default {
+	component: Button,
+};
+
+export const Loading = {
+	render: props => {
+		const [loading, isLoading] = React.useState(false);
+		return (
+			<Tooltip title="Relevant description of the basic button">
+				<Button.Primary
+					icon="talend-check"
+					loading={loading}
+					onClick={() => {
+						isLoading(true);
+						setTimeout(() => isLoading(false), 3000);
+					}}
+					{...props}
+				>
+					Async call to action
+				</Button.Primary>
+			</Tooltip>
+		);
+	},
+};

--- a/src/components/Button/docs/Button.stories.mdx
+++ b/src/components/Button/docs/Button.stories.mdx
@@ -2,6 +2,7 @@ import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
 import { action } from '@storybook/addon-actions';
 import { FigmaIframe, FigmaImage, FigmaLink, GitHubLink, Links, Use } from '../../../docs';
 import Button from '../';
+import * as Stories from '../Button.stories';
 import Skeleton from '../../Skeleton';
 import Tooltip from '../../Tooltip';
 import { IconsProvider } from '../../IconsProvider';
@@ -219,29 +220,8 @@ When the user clicks on the button, and the action is asynchronous, a spinner wi
 If the button has an icon, the spinner will temporary replace this icon as long as it's loading.
 No action will be possible until it's done.
 
-export const LoadingButton = props => {
-	const [loading, isLoading] = React.useState(false);
-	return (
-		<Tooltip title="Relevant description of the basic button">
-			<Button.Primary
-				icon="talend-check"
-				loading={loading}
-				onClick={() => {
-					isLoading(true);
-					setTimeout(() => isLoading(false), 3000);
-				}}
-				{...props}
-			>
-				Async call to action
-			</Button.Primary>
-		</Tooltip>
-	);
-};
-
 <Canvas>
-	<Story name="loading">
-		<LoadingButton />
-	</Story>
+	<Story story={Stories.Loading} />
 </Canvas>
 
 ## Content

--- a/src/components/Link/Link.spec.tsx
+++ b/src/components/Link/Link.spec.tsx
@@ -1,16 +1,25 @@
 /// <reference types="cypress" />
 
 import React from 'react';
+import { composeStories } from '@storybook/testing-react';
 
-import Link from '.';
+import * as Stories from './Link.stories';
+
+const { Default, WithIcon, External } = composeStories(Stories);
 
 context('<Link />', () => {
 	it('should render', () => {
-		cy.mount(
-			<Link iconBefore="information" target="_blank" href="https://help.talend.com">
-				Help
-			</Link>,
-		);
-		cy.get('.link').should('have.attr', 'title', 'Open in a new tab').should('contain', 'Help');
+		cy.mount(<Default />);
+		cy.get('.link').should('have.text', 'Link example');
+	});
+
+	it('should render icon', () => {
+		cy.mount(<WithIcon />);
+		cy.get('.link .link__icon').should('have.attr', 'name', 'talend-info-circle');
+	});
+
+	it('should render external', () => {
+		cy.mount(<External />);
+		cy.get('.link').should('have.attr', 'title', 'Open in a new tab');
 	});
 });

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,5 +1,11 @@
 import { WithSelector } from '../../docs';
 
+import Link from '.';
+
+export default {
+	component: Link,
+};
+
 export const defaultProps = {
 	href: '#',
 	children: 'Link example',

--- a/src/components/Tag/Tag.spec.tsx
+++ b/src/components/Tag/Tag.spec.tsx
@@ -1,12 +1,15 @@
 /// <reference types="cypress" />
 
 import React from 'react';
+import { composeStories } from '@storybook/testing-react';
 
-import Tag from './';
+import * as Stories from './Tag.stories';
+
+const { Default } = composeStories(Stories);
 
 context('<Tag />', () => {
 	it('should render', () => {
-		cy.mount(<Tag>Lorem ipsum</Tag>);
-		cy.get('.tag').should('have.text', 'Lorem ipsum');
+		cy.mount(<Default />);
+		cy.get('.tag').should('have.text', 'Example');
 	});
 });

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 import Tag from './Tag';
 
+export default {
+	component: Tag,
+};
+
 export const Template = ({ variant, ...rest }) => {
 	const Component = Tag[variant] || Tag;
 	Component.displayName = variant ? `Tag.${variant}` : 'Tag';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,6 +2784,11 @@
     prettier "^2.2.1"
     regenerator-runtime "^0.13.7"
 
+"@storybook/testing-react@1.0.0--canary.46.4a6c010.0":
+  version "1.0.0--canary.46.4a6c010.0"
+  resolved "https://registry.yarnpkg.com/@storybook/testing-react/-/testing-react-1.0.0--canary.46.4a6c010.0.tgz#cd6b81d6f49ebad77aeb5d89a39cdd85c6d9e67b"
+  integrity sha512-slWvhpugJ19upH9SNy6wDqDFLapHAVCx1X7YbNNEE3Ziol00NLlJzpb2HMwKP+NXY6WGC5cyAh9nNw+ROH1x/Q==
+
 "@storybook/theming@6.4.0-alpha.30":
   version "6.4.0-alpha.30"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.4.0-alpha.30.tgz#0619969aa256ef454c867783fcbf3a3ec8ed7b38"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Stories and E2E tests don't use the same JSX element

**What is the chosen solution to this problem?**
Define JSX once in the story and run E2E tests using the story too

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
