### PR TITLE
fix(components/InlineMessage): className was missing for variations

### DIFF
--- a/.changeset/happy-bottles-build.md
+++ b/.changeset/happy-bottles-build.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+className was missing for InlineMessage variations

--- a/src/components/InlineMessage/InlineMessage.stories.tsx
+++ b/src/components/InlineMessage/InlineMessage.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import InlineMessage from './InlineMessage';
 import Link from '../Link';
 
-export const Template = ({ variant, ...rest }) => {
+export const render = ({ variant, ...rest }) => {
 	const Component = InlineMessage[variant] || InlineMessage;
 	Component.displayName = variant ? `InlineMessage.${variant}` : 'InlineMessage';
 	return <Component {...rest} />;
@@ -15,90 +15,122 @@ export const defaultProps = {
 	link: <Link href="#">See more</Link>,
 };
 
-export const Information = Template.bind({});
-Information.args = {
-	...defaultProps,
-	variant: 'Information',
+export const Information = {
+	args: {
+		...defaultProps,
+		variant: 'Information',
+	},
+	render,
 };
-export const Success = Template.bind({});
-Success.args = {
-	...defaultProps,
-	variant: 'Success',
+export const Success = {
+	args: {
+		...defaultProps,
+		variant: 'Success',
+	},
+	render,
 };
-export const Warning = Template.bind({});
-Warning.args = {
-	...defaultProps,
-	variant: 'Warning',
+export const Warning = {
+	args: {
+		...defaultProps,
+		variant: 'Warning',
+	},
+	render,
 };
-export const Destructive = Template.bind({});
-Destructive.args = {
-	...defaultProps,
-	variant: 'Destructive',
-};
-
-export const InformationSmall = Template.bind({});
-InformationSmall.args = {
-	...Information.args,
-	small: true,
-};
-export const SuccessSmall = Template.bind({});
-SuccessSmall.args = {
-	...Success.args,
-	small: true,
-};
-export const WarningSmall = Template.bind({});
-WarningSmall.args = {
-	...Warning.args,
-	small: true,
-};
-export const DestructiveSmall = Template.bind({});
-DestructiveSmall.args = {
-	...Destructive.args,
-	small: true,
+export const Destructive = {
+	args: {
+		...defaultProps,
+		variant: 'Destructive',
+	},
+	render,
 };
 
-export const InformationBackground = Template.bind({});
-InformationBackground.args = {
-	...Information.args,
-	withBackground: true,
+export const InformationSmall = {
+	args: {
+		...Information.args,
+		small: true,
+	},
+	render,
 };
-export const SuccessBackground = Template.bind({});
-SuccessBackground.args = {
-	...Success.args,
-	withBackground: true,
+export const SuccessSmall = {
+	args: {
+		...Success.args,
+		small: true,
+	},
+	render,
 };
-export const WarningBackground = Template.bind({});
-WarningBackground.args = {
-	...Warning.args,
-	withBackground: true,
+export const WarningSmall = {
+	args: {
+		...Warning.args,
+		small: true,
+	},
+	render,
 };
-export const DestructiveBackground = Template.bind({});
-DestructiveBackground.args = {
-	...Destructive.args,
-	withBackground: true,
+export const DestructiveSmall = {
+	args: {
+		...Destructive.args,
+		small: true,
+	},
+	render,
 };
 
-export const InformationBackgroundSmall = Template.bind({});
-InformationBackgroundSmall.args = {
-	...Information.args,
-	small: true,
-	withBackground: true,
+export const InformationBackground = {
+	args: {
+		...Information.args,
+		withBackground: true,
+	},
+	render,
 };
-export const SuccessBackgroundSmall = Template.bind({});
-SuccessBackgroundSmall.args = {
-	...Success.args,
-	small: true,
-	withBackground: true,
+export const SuccessBackground = {
+	args: {
+		...Success.args,
+		withBackground: true,
+	},
+	render,
 };
-export const WarningBackgroundSmall = Template.bind({});
-WarningBackgroundSmall.args = {
-	...Warning.args,
-	small: true,
-	withBackground: true,
+export const WarningBackground = {
+	args: {
+		...Warning.args,
+		withBackground: true,
+	},
+	render,
 };
-export const DestructiveBackgroundSmall = Template.bind({});
-DestructiveBackgroundSmall.args = {
-	...Destructive.args,
-	small: true,
-	withBackground: true,
+export const DestructiveBackground = {
+	args: {
+		...Destructive.args,
+		withBackground: true,
+	},
+	render,
+};
+
+export const InformationBackgroundSmall = {
+	args: {
+		...Information.args,
+		small: true,
+		withBackground: true,
+	},
+	render,
+};
+export const SuccessBackgroundSmall = {
+	args: {
+		...Success.args,
+		small: true,
+		withBackground: true,
+	},
+	render,
+};
+export const WarningBackgroundSmall = {
+	args: {
+		...Warning.args,
+		small: true,
+		withBackground: true,
+	},
+	render,
+};
+export const DestructiveBackgroundSmall = {
+	args: {
+		...Destructive.args,
+		small: true,
+		withBackground: true,
+	},
+	render,
 };

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -7,52 +7,54 @@ export type InlineMessageProps = {
 	withBackground?: boolean;
 };
 
-export const InlineMessage = styled.div<InlineMessageProps>`
+export const InlineMessage = styled.div.attrs({
+	className: 'c-inline-message',
+})<InlineMessageProps>`
 	display: ${({ withBackground }) => (withBackground ? 'inline-flex' : 'inline')};
-	margin-bottom: ${tokens.space?.m};
-	${({ withBackground }) =>
-		withBackground ? `padding: ${tokens.space?.xs} ${tokens.space?.s};` : ''}
-	font-family: ${tokens.fonts?.sansSerif};
-	${({ small }) => (small ? `font-size: ${tokens.fontSizes?.small};` : '')}
-	border-radius: ${tokens.radii?.inputBorderRadius};
+	padding: ${({ withBackground }) =>
+		withBackground ? `${tokens.space.xs} ${tokens.space.s};` : 'inherit'};
+	font-family: ${tokens.fonts.sansSerif};
+	font-size: ${({ small }) => (small ? `${tokens.fontSizes.small};` : 'inherit')};
+	color: var(--c-inline-message-color, ${({ theme }) => theme.colors?.textColor});
+	background: var(--c-inline-message-background, transparent);
+	border-radius: ${tokens.radii.inputBorderRadius};
+	box-shadow: var(--c-inline-message-box-shadow, transparent);
+`;
 
+export const Icon = styled.span.attrs({
+	className: 'c-inline-message__icon',
+})<InlineMessageProps>`
+	padding-right: ${tokens.space.xs};
 	color: var(
-		--t-inline-message-icon-color,
+		--c-inline-message--icon-color,
 		${({ theme, withBackground }) =>
 			withBackground ? theme.colors?.backgroundColor : theme.colors?.textColor}
 	);
-	background: var(--t-inline-message-background, transparent);
-	box-shadow: var(--t-inline-message-box-shadow, transparent);
 
-	.inline-message__icon {
-		padding-right: ${tokens.space?.xs};
-
-		svg {
-			height: ${({ small }) => (small ? tokens.sizes?.s : tokens.sizes?.l)};
-			width: ${({ small }) => (small ? tokens.sizes?.s : tokens.sizes?.l)};
-		}
-
-		path {
-			fill: currentColor;
-		}
+	> svg {
+		height: ${({ small }) => (small ? tokens.sizes.s : tokens.sizes.l)};
+		width: ${({ small }) => (small ? tokens.sizes.s : tokens.sizes.l)};
+		// 🎩🐰
+		vertical-align: -2px;
 	}
 
-	.inline-message__icon,
-	p {
-		vertical-align: middle;
-	}
-
-	p {
-		display: inline;
-		margin: 0;
-	}
-
-	.inline-message__title {
-		font-weight: ${tokens.fontWeights?.semiBold};
-	}
-
-	.inline-message__title,
-	.inline-message__description {
-		color: var(--t-inline-message-color, ${({ theme }) => theme.colors?.textColor});
+	path {
+		fill: currentColor;
 	}
 `;
+export const Content = styled.p.attrs({})`
+	display: inline;
+	margin: 0;
+`;
+export const Text = styled.span``;
+export const Title = styled(Text).attrs({
+	className: 'c-inline-message__title',
+})`
+	font-weight: ${tokens.fontWeights.semiBold};
+`;
+export const Description = styled(Text).attrs({
+	className: 'c-inline-message__description',
+})``;
+export const Link = styled.span.attrs({
+	className: 'c-inline-message__link',
+})``;

--- a/src/components/InlineMessage/InlineMessage.tsx
+++ b/src/components/InlineMessage/InlineMessage.tsx
@@ -30,49 +30,36 @@ export type InlineMessageProps = PropsWithChildren<any> &
  * */
 const InlineMessage = React.forwardRef(
 	(
-		{
-			icon,
-			title,
-			description,
-			link,
-			className = '',
-			withBackground,
-			theme,
-			...rest
-		}: InlineMessageProps,
+		{ icon, title, description, link, small, withBackground, theme, ...rest }: InlineMessageProps,
 		ref,
 	) => (
 		<S.InlineMessage
 			role="status"
 			aria-live="polite"
 			{...rest}
-			className={`inline-message ${className || ''}`}
-			theme={withBackground ? light : theme}
+			small={small}
 			withBackground={withBackground}
+			theme={withBackground ? light : theme}
 			ref={ref}
 		>
 			{icon && (
-				<span className="inline-message__icon">
+				<S.Icon small={small}>
 					<Icon name={icon} />
-				</span>
+				</S.Icon>
 			)}
-			<p>
+			<S.Content>
 				{title && (
 					<>
-						<span className="inline-message__title">{title}</span>{' '}
+						<S.Title>{title}</S.Title>{' '}
 					</>
 				)}
-				{description && (
-					<>
-						<span className="inline-message__description">{description}</span>{' '}
-					</>
-				)}
+				<>
+					<S.Description>{description}</S.Description>{' '}
+				</>
 				{link && (
-					<span className="inline-message__link">
-						{React.cloneElement(link, { theme: withBackground ? light : theme })}
-					</span>
+					<S.Link>{React.cloneElement(link, { theme: withBackground ? light : theme })}</S.Link>
 				)}
-			</p>
+			</S.Content>
 		</S.InlineMessage>
 	),
 );

--- a/src/components/InlineMessage/docs/InlineMessage.stories.mdx
+++ b/src/components/InlineMessage/docs/InlineMessage.stories.mdx
@@ -25,7 +25,7 @@ It can be additional information related to system status, it can be a required 
 ### Icons
 
 <IconGallery>
-	{['talend-info-circle', 'talend-check', 'talend-warning', 'talend-error'].map(
+	{['talend-info-circle', 'talend-check-circle', 'talend-warning', 'talend-error'].map(
 		(iconName, index) => (
 			<IconItem key={index} name={iconName}>
 				<Icon name={iconName} />
@@ -156,7 +156,7 @@ Error messages should tell why there was a problem and what could be done to res
 			},
 		}}
 	>
-		{Stories.Template.bind({})}
+		{Stories.render.bind({})}
 	</Story>
 </Canvas>
 

--- a/src/components/InlineMessage/variations/InlineMessage.destructive.tsx
+++ b/src/components/InlineMessage/variations/InlineMessage.destructive.tsx
@@ -4,12 +4,13 @@ import { tint } from 'polished';
 import InlineMessage from '../InlineMessage';
 
 const InlineMessageDestructive = styled(InlineMessage).attrs({
+	className: 'c-inline-message--destructive',
 	icon: 'talend-error',
 })`
-	--t-inline-message-icon-color: ${({ theme }) => theme.colors?.destructiveColor[500]};
-	--t-inline-message-background: ${({ withBackground, theme }) =>
+	--c-inline-message--icon-color: ${({ theme }) => theme.colors?.destructiveColor[500]};
+	--c-inline-message-background: ${({ withBackground, theme }) =>
 		withBackground && tint(0.95, theme.colors?.destructiveColor[500])};
-	--t-inline-message-box-shadow: ${({ withBackground, theme }) =>
+	--c-inline-message-box-shadow: ${({ withBackground, theme }) =>
 		withBackground && `0 1px 2px ${tint(0.75, theme.colors?.destructiveColor[500])}`};
 `;
 

--- a/src/components/InlineMessage/variations/InlineMessage.information.tsx
+++ b/src/components/InlineMessage/variations/InlineMessage.information.tsx
@@ -4,12 +4,13 @@ import { tint } from 'polished';
 import InlineMessage from '../InlineMessage';
 
 const InlineMessageInformation = styled(InlineMessage).attrs({
+	className: 'c-inline-message--information',
 	icon: 'talend-info-circle',
 })`
-	--t-inline-message-icon-color: ${({ theme }) => theme.colors?.informationColor[500]};
-	--t-inline-message-background: ${({ withBackground, theme }) =>
+	--c-inline-message--icon-color: ${({ theme }) => theme.colors?.informationColor[500]};
+	--c-inline-message-background: ${({ withBackground, theme }) =>
 		withBackground && tint(0.95, theme.colors?.informationColor[500])};
-	--t-inline-message-box-shadow: ${({ withBackground, theme }) =>
+	--c-inline-message-box-shadow: ${({ withBackground, theme }) =>
 		withBackground && `0 1px 2px ${tint(0.75, theme.colors?.informationColor[500])}`};
 `;
 

--- a/src/components/InlineMessage/variations/InlineMessage.success.tsx
+++ b/src/components/InlineMessage/variations/InlineMessage.success.tsx
@@ -4,12 +4,13 @@ import { tint } from 'polished';
 import InlineMessage from '../InlineMessage';
 
 const InlineMessageSuccess = styled(InlineMessage).attrs({
+	className: 'c-inline-message--success',
 	icon: 'talend-check-circle',
 })`
-	--t-inline-message-icon-color: ${({ theme }) => theme.colors?.successColor[500]};
-	--t-inline-message-background: ${({ withBackground, theme }) =>
+	--c-inline-message--icon-color: ${({ theme }) => theme.colors?.successColor[500]};
+	--c-inline-message-background: ${({ withBackground, theme }) =>
 		withBackground && tint(0.95, theme.colors?.successColor[500])};
-	--t-inline-message-box-shadow: ${({ withBackground, theme }) =>
+	--c-inline-message-box-shadow: ${({ withBackground, theme }) =>
 		withBackground && `0 1px 2px ${tint(0.75, theme.colors?.successColor[500])}`};
 `;
 

--- a/src/components/InlineMessage/variations/InlineMessage.warning.tsx
+++ b/src/components/InlineMessage/variations/InlineMessage.warning.tsx
@@ -4,12 +4,13 @@ import { tint } from 'polished';
 import InlineMessage from '../InlineMessage';
 
 const InlineMessageWarning = styled(InlineMessage).attrs({
+	className: 'c-inline-message--warning',
 	icon: 'talend-warning',
 })`
-	--t-inline-message-icon-color: ${({ theme }) => theme.colors?.warningColor[500]};
-	--t-inline-message-background: ${({ withBackground, theme }) =>
+	--c-inline-message--icon-color: ${({ theme }) => theme.colors?.warningColor[500]};
+	--c-inline-message-background: ${({ withBackground, theme }) =>
 		withBackground && tint(0.95, theme.colors?.warningColor[500])};
-	--t-inline-message-box-shadow: ${({ withBackground, theme }) =>
+	--c-inline-message-box-shadow: ${({ withBackground, theme }) =>
 		withBackground && `0 1px 2px ${tint(0.75, theme.colors?.warningColor[500])}`};
 `;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
InlineMessage has no readable className for its variations

**What is the chosen solution to this problem?**
Add it and harmonize its custom properties naming

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
