### PR TITLE
fix(components/InlineMessage): text-align at start

### DIFF
--- a/.changeset/kind-rats-taste.md
+++ b/.changeset/kind-rats-taste.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+InlineMessage should have text-align at start

--- a/src/components/InlineMessage/InlineMessage.style.ts
+++ b/src/components/InlineMessage/InlineMessage.style.ts
@@ -15,6 +15,7 @@ export const InlineMessage = styled.div.attrs({
 		withBackground ? `${tokens.space.xs} ${tokens.space.s};` : 'inherit'};
 	font-family: ${tokens.fonts.sansSerif};
 	font-size: ${({ small }) => (small ? `${tokens.fontSizes.small};` : 'inherit')};
+	text-align: start;
 	color: var(--c-inline-message-color, ${({ theme }) => theme.colors?.textColor});
 	background: var(--c-inline-message-background, transparent);
 	border-radius: ${tokens.radii.inputBorderRadius};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If the container has text-align at the center, then the text of InlineMessage will be centered

**What is the chosen solution to this problem?**
Force the text of InlineMessage to be at start

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
