### PR TITLE
doc(Components/Form/Password): pseudo-states

### DIFF
--- a/src/components/Form/Field/Input/Password/Password.stories.mdx
+++ b/src/components/Form/Field/Input/Password/Password.stories.mdx
@@ -28,6 +28,8 @@ It will vary depending on the user agent and OS.
 
 <Canvas>
 	<Story story={Stories.Default} />
+	<Story story={Stories.Hover} />
+	<Story story={Stories.Focus} />
 </Canvas>
 
 ### Placeholder

--- a/src/components/Form/Field/Input/Password/Password.stories.tsx
+++ b/src/components/Form/Field/Input/Password/Password.stories.tsx
@@ -1,5 +1,8 @@
+import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+import { WithSelector } from '../../../../../docs';
 
 import Form from '../../..';
 
@@ -7,53 +10,21 @@ export default {
 	component: Form.Password,
 };
 
-export const defaultProps = {
-	label: 'Password',
-	defaultValue: 'Passw0rd',
-};
+export const Default = () => <Form.Password label="Password" />;
+export const Hover = () => <Form.Password label="Password :hover" />;
+Hover.decorators = [WithSelector.decorator(':hover')];
+export const Focus = () => <Form.Password label="Password :focus" />;
+Focus.decorators = [WithSelector.decorator(':focus')];
 
-export const Default = {
-	args: {
-		...defaultProps,
-		defaultValue: undefined,
-	},
+export const Placeholder = () => (
+	<Form.Password label="Password" placeholder="Type your password" />
+);
+export const Filled = () => <Form.Password label="Password" defaultValue="Passw0rd" />;
+export const Revealed = () => <Form.Password label="Password" defaultValue="Passw0rd" />;
+Revealed.play = () => {
+	const button = screen.getByTestId('form.password.reveal');
+	userEvent.click(button);
 };
-
-export const Placeholder = {
-	args: {
-		...defaultProps,
-		defaultValue: undefined,
-		placeholder: 'Type your password',
-	},
-};
-
-export const Filled = {
-	args: {
-		...defaultProps,
-	},
-};
-
-export const Revealed = {
-	args: {
-		...defaultProps,
-	},
-	play() {
-		const button = screen.getByTestId('form.password.reveal');
-		userEvent.click(button);
-	},
-	parameters: { docs: { disable: true } },
-};
-
-export const Disabled = {
-	args: {
-		...defaultProps,
-		disabled: true,
-	},
-};
-
-export const ReadOnly = {
-	args: {
-		...defaultProps,
-		readOnly: true,
-	},
-};
+Revealed.parameters = { docs: { disable: true } };
+export const Disabled = () => <Form.Password label="Password" defaultValue="Passw0rd" disabled />;
+export const ReadOnly = () => <Form.Password label="Password" defaultValue="Passw0rd" readOnly />;

--- a/src/components/Form/Field/Input/Password/Password.tsx
+++ b/src/components/Form/Field/Input/Password/Password.tsx
@@ -1,11 +1,13 @@
-import React, { useRef } from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 import Input, { InputProps } from '../Input';
 
 import useRevealPassword from '../hooks/useRevealPassword';
 
-const Password = React.forwardRef((props: InputProps, ref: React.Ref<HTMLInputElement>) => {
+const Password = React.forwardRef((props: InputProps, ref: React.Ref<HTMLInputElement | null>) => {
 	const { currentType, onReset, RevealPasswordButton } = useRevealPassword();
 	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	useImperativeHandle(ref, () => inputRef.current);
 
 	function handleClick() {
 		if (inputRef.current) {
@@ -16,20 +18,18 @@ const Password = React.forwardRef((props: InputProps, ref: React.Ref<HTMLInputEl
 	}
 
 	return (
-		<div ref={ref}>
-			<Input
-				{...props}
-				type={currentType}
-				ref={inputRef}
-				onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
-					onReset();
-					if (props.onBlur) {
-						props.onBlur(event);
-					}
-				}}
-				after={<RevealPasswordButton onClick={() => handleClick()} disabled={props.disabled} />}
-			/>
-		</div>
+		<Input
+			{...props}
+			type={currentType}
+			ref={inputRef}
+			onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
+				onReset();
+				if (props.onBlur) {
+					props.onBlur(event);
+				}
+			}}
+			after={<RevealPasswordButton onClick={() => handleClick()} disabled={props.disabled} />}
+		/>
 	);
 });
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Pseudo states for the Password input were missing

**What is the chosen solution to this problem?**
Add them by using [React.useimperativehandle](https://reactjs.org/docs/hooks-reference.html#useimperativehandle)

![image](https://user-images.githubusercontent.com/18534166/137402900-ba54cd37-19de-4246-97cd-bb9d1104d467.png)

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
