### PR TITLE
feat(components/tooltip): optional

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
-import { FigmaIframe, FigmaImage, Use } from '../../../docs';
+import { FigmaIframe, FigmaImage, Use } from '../../docs';
 
-import * as Stories from '../Tooltip.stories';
+import * as Stories from './Tooltip.stories';
 
 <Meta title="Components/Tooltip" />
 
@@ -28,6 +28,15 @@ Tooltips provide helpful, additional content for their paired elements on hover.
 	<Story story={Stories.Left} />
 	<Story story={Stories.Bottom} />
 	<Story story={Stories.Right} />
+</Canvas>
+
+## Interactions
+
+Tooltip can be `optional` depending on its content length.
+
+<Canvas>
+	<Story story={Stories.ShortOptional} />
+	<Story story={Stories.LongOptional} />
 </Canvas>
 
 ## Content

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -25,3 +25,34 @@ Bottom.args = { ...defaultProps, placement: 'bottom' };
 
 export const Left = Template.bind({});
 Left.args = { ...defaultProps, placement: 'left' };
+
+export const ShortOptional = () => (
+	<Tooltip title="Lorem ipsum" optional>
+		<span>Lorem ipsum</span>
+	</Tooltip>
+);
+export const LongOptional = () => (
+	<Tooltip
+		title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin a tincidunt dui. Vestibulum lorem libero, consequat in odio at, pellentesque bibendum risus. Duis ullamcorper dolor sit amet purus porttitor, ac feugiat nulla viverra. Donec imperdiet feugiat nulla non scelerisque. Integer facilisis nisi quis nunc vehicula viverra. Etiam aliquam feugiat lorem in hendrerit. Nam vel elit dapibus, accumsan nisl at, posuere eros. Pellentesque euismod massa nec mollis dapibus. Aenean mollis magna dolor, quis dignissim orci suscipit a. Maecenas at augue odio. Mauris in lorem convallis, fringilla neque eu, laoreet ligula. Donec consequat quam sed est pulvinar, eu ultrices urna condimentum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos."
+		optional
+	>
+		<p style={{ whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }}>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin a tincidunt dui. Vestibulum
+			lorem libero, consequat in odio at, pellentesque bibendum risus. Duis ullamcorper dolor sit
+			amet purus porttitor, ac feugiat nulla viverra. Donec imperdiet feugiat nulla non scelerisque.
+			Integer facilisis nisi quis nunc vehicula viverra. Etiam aliquam feugiat lorem in hendrerit.
+			Nam vel elit dapibus, accumsan nisl at, posuere eros. Pellentesque euismod massa nec mollis
+			dapibus. Aenean mollis magna dolor, quis dignissim orci suscipit a. Maecenas at augue odio.
+			Mauris in lorem convallis, fringilla neque eu, laoreet ligula. Donec consequat quam sed est
+			pulvinar, eu ultrices urna condimentum. Class aptent taciti sociosqu ad litora torquent per
+			conubia nostra, per inceptos himenaeos.
+		</p>
+	</Tooltip>
+);
+LongOptional.decorators = [
+	Story => (
+		<div style={{ maxWidth: '30rem' }}>
+			<Story />
+		</div>
+	),
+];


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We need to display tooltip only if there is content exceeding the available place

**What is the chosen solution to this problem?**
Display tooltip only if there is text-overflow

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
