### PR TITLE
fix(InlineEditing): textarea is broken on safari

### DIFF
--- a/.changeset/lovely-otters-poke.md
+++ b/.changeset/lovely-otters-poke.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(InlineEditing): textarea is broken on safari

--- a/src/components/InlineEditing/variations/InlineEditing.textarea.tsx
+++ b/src/components/InlineEditing/variations/InlineEditing.textarea.tsx
@@ -8,17 +8,17 @@ const InlineEditingMulti: React.FC<InlineEditingProps> = styled(InlineEditing).a
 	renderAs: 'p',
 	mode: Mode.Multi,
 })`
-	.c-inline-editing--editing.c-inline-editing__field .c-inline-editing__actions {
+	.c-inline-editing--editing .c-inline-editing__actions {
 		padding-top: 1rem;
 		height: 2.2rem;
 	}
 
-	.c-inline-editing--editing.c-inline-editing__field textarea {
+	.c-inline-editing--editing textarea {
 		padding: 1rem;
 		padding-right: 4rem;
 	}
 
-	.c-inline-editing--static.c-inline-editing__field .c-inline-editing__value {
+	.c-inline-editing--static .c-inline-editing__value {
 		white-space: inherit;
 	}
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

![image](https://user-images.githubusercontent.com/26482371/139067505-adb893e7-0630-40ca-b569-ba635cc3e26e.png)

**What is the chosen solution to this problem?**

fix css

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
