### PR TITLE
fix(components): Usage of index as key breaks component state

### DIFF
--- a/.changeset/violet-carrots-compare.md
+++ b/.changeset/violet-carrots-compare.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Removed usage of array index as key

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -15,7 +15,6 @@ const Accordion = React.forwardRef<React.ReactElement, React.PropsWithChildren<a
 				{children.map((child: React.ReactElement, key: number) =>
 					React.cloneElement(child, {
 						id: `${composite.baseId}-${key + 1}`,
-						key: `accordion-item-${key}`,
 						...composite,
 						...child.props,
 					}),

--- a/src/components/Form/Buttons/Buttons.tsx
+++ b/src/components/Form/Buttons/Buttons.tsx
@@ -16,13 +16,8 @@ const Buttons = React.forwardRef(
 
 		return (
 			<S.Buttons className="c-form__buttons" {...rest} ref={ref}>
-				{React.Children.toArray(children).map((child, key: number) =>
-					isElement(child)
-						? React.cloneElement(child, {
-								...childrenProps,
-								key: `buttons-${key}`,
-						  })
-						: child,
+				{React.Children.toArray(children).map(child =>
+					isElement(child) ? React.cloneElement(child, childrenProps) : child,
 				)}
 			</S.Buttons>
 		);

--- a/src/components/Form/Fieldset/Fieldset.spec.tsx
+++ b/src/components/Form/Fieldset/Fieldset.spec.tsx
@@ -1,0 +1,36 @@
+/// <reference types="cypress" />
+
+import React, { useState } from 'react';
+import Fieldset from './Fieldset';
+import Button from '../../Button';
+import ThemeProvider from '../../ThemeProvider';
+
+context('<Fieldset />', () => {
+	it('should preserve children component state between renders', () => {
+		const TestComponentWithState = () => {
+			const [value] = useState(Math.random());
+			return <div data-test="random-value-on-mount">{value}</div>;
+		};
+
+		const Wrapper = () => {
+			const [hasError, setHasError] = useState(false);
+			return (
+				<ThemeProvider theme={undefined}>
+					<Fieldset>
+						{hasError ? <span>Error message</span> : null}
+						<TestComponentWithState />
+					</Fieldset>
+					<Button.Primary onClick={() => setHasError(!hasError)}>Toggle error</Button.Primary>
+				</ThemeProvider>
+			);
+		};
+
+		cy.mount(<Wrapper />);
+		cy.get('[data-test="random-value-on-mount"]')
+			.invoke('val')
+			.then(value => {
+				cy.get('button').click();
+				cy.get('[data-test="random-value-on-mount"]').should('contain', value);
+			});
+	});
+});

--- a/src/components/Form/Fieldset/Fieldset.tsx
+++ b/src/components/Form/Fieldset/Fieldset.tsx
@@ -22,13 +22,8 @@ const Fieldset = React.forwardRef(
 						{required && '*'}
 					</S.Legend>
 				)}
-				{React.Children.toArray(children).map((child, key: number) =>
-					isElement(child)
-						? React.cloneElement(child, {
-								...childrenProps,
-								key: `fieldset-${key}`,
-						  })
-						: child,
+				{React.Children.toArray(children).map((child, key) =>
+					isElement(child) ? React.cloneElement(child, childrenProps) : child,
 				)}
 			</S.Fieldset>
 		);

--- a/src/components/Form/Fieldset/Fieldset.tsx
+++ b/src/components/Form/Fieldset/Fieldset.tsx
@@ -22,7 +22,7 @@ const Fieldset = React.forwardRef(
 						{required && '*'}
 					</S.Legend>
 				)}
-				{React.Children.toArray(children).map((child, key) =>
+				{React.Children.toArray(children).map((child) =>
 					isElement(child) ? React.cloneElement(child, childrenProps) : child,
 				)}
 			</S.Fieldset>

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -16,13 +16,8 @@ const Form = React.forwardRef(
 
 		return (
 			<S.Form className="c-form" {...rest} ref={ref}>
-				{React.Children.toArray(children).map((child, key: number) =>
-					isElement(child)
-						? React.cloneElement(child, {
-								...childrenProps,
-								key: `form-${key}`,
-						  })
-						: child,
+				{React.Children.toArray(children).map(child =>
+					isElement(child) ? React.cloneElement(child, childrenProps) : child,
 				)}
 			</S.Form>
 		);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Usage of index as key will break component state if children change.
https://reactjs.org/docs/lists-and-keys.html
`We don’t recommend using indexes for keys if the order of items may change. This can negatively impact performance and may cause issues with component state. `

**What is the chosen solution to this problem?**

Don't use keys when you can't assume the elements will not change/reorder

**Please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
