### PR TITLE
doc(adr): data-test attributes

### DIFF
--- a/adr/data-test.md
+++ b/adr/data-test.md
@@ -1,0 +1,55 @@
+# [data-test] attributes
+
+## Context
+
+Quality Assurance teams perform automated tests on Products for non-regression testing.
+
+## Problems
+
+QA teams lean on HTML ID attributes or XPath to automate tests on UI, and updates on the shared library can break these scenarios.
+
+## Solutions
+
+Expose [data-test] attributes for QA purpose suggest in the components or layout markup.
+1 — By documenting them, the first benefit will be to act on a contract with our QA team.
+2 — By using them, after all, the second benefit will also be to perform component testing.
+
+```css
+[data-test="<block_name>.<element_type>[?<element_index>].<?element_identifier>"]
+```
+
+| Identifier           | Optional | Description                                                                                                                                                      |
+| -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block_name`         |          | Component or layout identifier from our design language (ex: modal, search, password, inlineediting, etc.)                                                       |
+| `element_type`       |          | Element or its type used (ex: button, link, input, textarea, radio, etc.)                                                                                        |
+| `element_index`      | yes      | Element index if it's repeated (radio, menu items, etc.)                                                                                                         |
+| `element_identifier` | yes      | A short and comprehensive identifier when we talk about it each other, in case of a form field we can reuse its label value (reveal, cancel, edit, submit, etc.) |
+
+We need to precise something,
+
+> To decide which values to use and to live in the Design System, we definitively have to be **context agnostic**.
+> It seems we can't determine if we will use the input for a `first name` or an `API key name`.
+> That's why we need to **keep it simple and stupid**.
+
+Keep in mind that the Product teams can add `[data-testid]` to give a more comprehensive identifier.
+The ones we embed are here in addition to what the product team can provide.
+`[data-test]` are just the default ones that we can agree on, to be able to write E2E tests without worrying about the HTML markup or the CSS.
+
+### Examples
+
+- For a "Close" button of a `Modal`
+  `[data-test="modal.button.close"]`
+
+- For a "Reveal" button of a `Password` form field
+  `[data-test="password.button.reveal"]`
+
+- For a textarea of the `Inline Editing` in edition mode
+  `[data-test="inlineediting.textarea"]`
+
+- For a filter of a list
+  `[data-test="search.input"]`
+
+- For a `Switch` with three options, which it used radio buttons under the hood
+  `[data-test="switch.radio[1]"]` `[data-test="switch.radio[2]"]` `[data-test="switch.radio[3]"]`
+
+All of this will be part of the documentation (see below) and each of them will be used in [Cypress component testing](https://docs.cypress.io/guides/component-testing/introduction) in our Design System codebase.


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
QA lean on ID or XPATH for their tests,  which can break when the DS  is released.

**What is the chosen solution to this problem?**
Architecture Decision Record to systematically use [data-test]

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
