### PR TITLE
fix(ThemeProvider): Handle nested providers

### DIFF
--- a/.changeset/dry-tomatoes-grow.md
+++ b/.changeset/dry-tomatoes-grow.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(ThemeProvider): Handle nested providers

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
 	DefaultTheme,
 	ThemeProvider as StyledThemeProvider,
@@ -11,16 +11,17 @@ import defaultTheme from '../../themes';
 
 const ThemeProvider = ({ theme = defaultTheme, children }: ThemeProviderProps<any>) => {
 	const [selectedTheme, setSelectedTheme] = useState(theme);
+	// Handle nested Providers: parent Provider doesn't have context, child does
+	const context = useContext(ThemeContext);
 
 	React.useEffect(() => {
 		setSelectedTheme(theme);
 	}, [theme]);
 
 	const switchTheme = (newTheme: DefaultTheme) => setSelectedTheme(newTheme);
-
 	return (
-		<ThemeContext.Provider value={{ switchTheme, theme: selectedTheme }}>
-			<StyledThemeProvider theme={selectedTheme}>{children}</StyledThemeProvider>
+		<ThemeContext.Provider value={context.theme ? context : { switchTheme, theme: selectedTheme }}>
+			<StyledThemeProvider theme={context?.theme || selectedTheme}>{children}</StyledThemeProvider>
 		</ThemeContext.Provider>
 	);
 };

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -21,7 +21,7 @@ const ThemeProvider = ({ theme = defaultTheme, children }: ThemeProviderProps<an
 	const switchTheme = (newTheme: DefaultTheme) => setSelectedTheme(newTheme);
 	return (
 		<ThemeContext.Provider value={context.theme ? context : { switchTheme, theme: selectedTheme }}>
-			<StyledThemeProvider theme={context?.theme || selectedTheme}>{children}</StyledThemeProvider>
+			<StyledThemeProvider theme={context.theme || selectedTheme}>{children}</StyledThemeProvider>
 		</ThemeContext.Provider>
 	);
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We have nested ThemeProvider in TUI Layout, which is not ideal but something we have to deal with

```
<ThemeProvider theme={theme}>
  <ThemeProvider>
    <Component/>   
  </ThemeProvider>
</ThemeProvider>
```

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
