### PR TITLE
feat(themes): Expose dictionaries into the UMD

### DIFF
--- a/.changeset/moody-suits-pump.md
+++ b/.changeset/moody-suits-pump.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Expose design tokens dictionaries into the UMD

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -7,9 +7,9 @@ import {
 
 import ThemeContext from './ThemeContext';
 
-import defaultTheme from '../../themes';
+import { light } from '../../themes';
 
-const ThemeProvider = ({ theme = defaultTheme, children }: ThemeProviderProps<any>) => {
+const ThemeProvider = ({ theme = light, children }: ThemeProviderProps<any>) => {
 	const [selectedTheme, setSelectedTheme] = useState(theme);
 	// Handle nested Providers: parent Provider doesn't have context, child does
 	const context = useContext(ThemeContext);

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,8 +1,9 @@
 import light from './light.theme';
 import dark from './dark.theme';
 
+import lightDictionary from './light/dictionary';
+import darkDictionary from './dark/dictionary';
+
 import './themes.scss';
 
-export { light, dark };
-
-export default light;
+export default { light, lightDictionary, dark, darkDictionary };

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -6,4 +6,4 @@ import darkDictionary from './dark/dictionary';
 
 import './themes.scss';
 
-export default { light, lightDictionary, dark, darkDictionary };
+export { light, lightDictionary, dark, darkDictionary };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Theme dictionary  was not in the UMD

**What is the chosen solution to this problem?**
Add them all

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
