### PR TITLE
fix(components/switch): no animation with defaultValue

### DIFF
--- a/.changeset/poor-seals-behave.md
+++ b/.changeset/poor-seals-behave.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(components/switch): no animation with defaultValue

--- a/src/components/Switch/Switch.style.ts
+++ b/src/components/Switch/Switch.style.ts
@@ -9,8 +9,11 @@ export const SwitchIndicator = styled.span`
 	left: 0;
 	width: 0;
 	bottom: 0;
-	transition: ${tokens.transitions.fast};
 	z-index: ${tokens.zIndices.above};
+
+	&[data-animated='true'] {
+		transition: ${tokens.transitions.fast};
+	}
 `;
 
 export const Switch = styled.div<{ disabled: boolean; readOnly: boolean }>`

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -6,6 +6,7 @@ import * as S from './Switch.style';
 export type SwitchProps = React.PropsWithChildren<any> & {
 	label: string;
 	value?: string;
+	defaultValue?: string;
 	values?: any[];
 	checked: boolean;
 	disabled: boolean;
@@ -15,6 +16,7 @@ export type SwitchProps = React.PropsWithChildren<any> & {
 const Switch = ({
 	label,
 	value,
+	defaultValue,
 	values,
 	checked,
 	disabled,
@@ -23,7 +25,7 @@ const Switch = ({
 	...rest
 }: SwitchProps) => {
 	const radio = useRadioState({
-		state: value || (values && values[0]),
+		state: value || defaultValue || (values && values[0]),
 		loop: false,
 		unstable_virtual: true,
 	});
@@ -54,12 +56,13 @@ const Switch = ({
 		const checkedRadioSpanWidth = checkedElement.scrollWidth;
 		const switchIndicatorRef = switchIndicator?.current;
 		if (switchIndicatorRef) {
+			switchIndicatorRef.style.width = `${checkedRadioSpanWidth}px`;
 			switchIndicatorRef.style.transform = `translateX(${radioWidths
 				.slice(0, checkedRadioIndex)
 				.reduce((accumulator, currentValue) => accumulator + currentValue, 0)}px)`;
-			switchIndicatorRef.style.width = `${checkedRadioSpanWidth}px`;
+			switchIndicatorRef.dataset.animated = true;
 		}
-	}, [radio]);
+	}, [radio, defaultValue]);
 
 	return (
 		<S.Switch readOnly={readOnly} disabled={disabled}>
@@ -81,7 +84,7 @@ const Switch = ({
 						</Radio>
 					);
 				})}
-				<S.SwitchIndicator ref={switchIndicator} aria-hidden="true">
+				<S.SwitchIndicator ref={switchIndicator} data-animated={false} aria-hidden="true">
 					<em />
 				</S.SwitchIndicator>
 			</RadioGroup>

--- a/src/components/Switch/docs/Switch.stories.mdx
+++ b/src/components/Switch/docs/Switch.stories.mdx
@@ -55,6 +55,25 @@ Use switches to change the state of system functionalities and preferences on or
 
 ## Usage
 
+<Canvas>
+	<Story name="uncontrolled">
+		{() => {
+			const defaultValue = 'value f';
+			const [value, setValue] = React.useState(defaultValue);
+			return (
+				<>
+					<p>Selected value: {value}</p>
+					<Switch
+						values={['value a', 'value b', 'value c', 'value d', 'value e', 'value f']}
+						defaultValue={defaultValue}
+						onChange={(e, v) => setValue(v)}
+					/>
+				</>
+			);
+		}}
+	</Story>
+</Canvas>
+
 ## Changelog
 
 | Date       | Author           | Description |


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
At the very first render, switch indicator has an animation

**What is the chosen solution to this problem?**
Remove the animation only for first render

**Please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Changelog has been commited, e.g: `yarn changeset`
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
